### PR TITLE
FROMLIST: PCI: qcom: Add QCS615 PCIe support

### DIFF
--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -1939,6 +1939,7 @@ static const struct of_device_id qcom_pcie_match[] = {
 	{ .compatible = "qcom,pcie-sm8450-pcie1", .data = &cfg_1_9_0 },
 	{ .compatible = "qcom,pcie-sm8550", .data = &cfg_1_9_0 },
 	{ .compatible = "qcom,pcie-x1e80100", .data = &cfg_sc8280xp },
+	{ .compatible = "qcom,qcs615-pcie", .data = &cfg_1_9_0 },
 	{ }
 };
 


### PR DESCRIPTION
Add the compatible and the driver data for QCS615 PCIe controller
