### PR TITLE
BACKPORT: dt-bindings: PCI: qcom,pcie-sa8775p: document qcs8300

### DIFF
--- a/Documentation/devicetree/bindings/pci/qcom,pcie-sa8775p.yaml
+++ b/Documentation/devicetree/bindings/pci/qcom,pcie-sa8775p.yaml
@@ -16,7 +16,12 @@ description:
 
 properties:
   compatible:
-    const: qcom,pcie-sa8775p
+    oneOf:
+      - const: qcom,pcie-sa8775p
+      - items:
+          - enum:
+              - qcom,pcie-qcs8300
+          - const: qcom,pcie-sa8775p
 
   reg:
     minItems: 6


### PR DESCRIPTION
Add compatible for qcs8300 platform, with sa8775p as the fallback.
Link: https://lore.kernel.org/all/20250529035635.4162149-3-quic_ziyuzhan@quicinc.com/