### PR TITLE
FROMLIST: arm64: dts: qcom: qcs615: Set LDO12A regulator to HPM to av…

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+++ b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
@@ -247,10 +247,7 @@
 			regulator-name = "vreg_l12a";
 			regulator-min-microvolt = <1800000>;
 			regulator-max-microvolt = <1890000>;
-			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
-			regulator-allow-set-load;
-			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
-						   RPMH_REGULATOR_MODE_HPM>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 		};
 
 		vreg_l13a: ldo13 {


### PR DESCRIPTION
…oid boot hang

On certain platforms (e.g., QCS615), consumers of LDO12A—such as PCIe, UFS, and eMMC—may draw more than 10mA of current during boot. This can exceed the regulator's limit in Low Power Mode (LPM), triggering current limit protection and causing the system to hang.

To address this, there are two possible approaches: a) Set the regulator's initial mode to High Performance Mode (HPM) in
   the device tree.
b) Keep the default LPM setting and have each consumer driver explicitly
   set its current load.

Since some regulators are shared among multiple consumers, and setting the current must be coordinated across all of them, we will initially adopt option a by setting the regulator to HPM. We can later migrate to option b when the timing is appropriate and all consumer drivers are ready.

Link: https://lore.kernel.org/all/20250717072746.987298-1-quic_ziyuzhan@quicinc.com/