### PR TITLE
FROMLIST: arm64: dts: qcom: sa8775p: Add gpu and gmu nodes

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -1098,6 +1098,18 @@
 			#mbox-cells = <2>;
 		};
 
+		qfprom: efuse@784000 {
+			compatible = "qcom,sa8775p-qfprom", "qcom,qfprom";
+			reg = <0x0 0x00784000 0x0 0x2410>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			gpu_speed_bin: gpu_speed_bin@240c {
+				reg = <0x240c 0x1>;
+				bits = <0 8>;
+			};
+		};
+
 		gpi_dma2: dma-controller@800000  {
 			compatible = "qcom,sa8775p-gpi-dma", "qcom,sm6350-gpi-dma";
 			reg = <0x0 0x00800000 0x0 0x60000>;
@@ -4142,6 +4154,9 @@
 			interconnect-names = "gfx-mem";
 			#cooling-cells = <2>;
 
+			nvmem-cells = <&gpu_speed_bin>;
+			nvmem-cell-names = "speed_bin";
+
 			status = "disabled";
 
 			gpu_zap_shader: zap-shader {
@@ -4155,24 +4170,28 @@
 					opp-hz = /bits/ 64 <405000000>;
 					opp-level = <RPMH_REGULATOR_LEVEL_SVS_L1>;
 					opp-peak-kBps = <5285156>;
+					opp-supported-hw = <0x3>;
 				};
 
 				opp-676000000 {
 					opp-hz = /bits/ 64 <676000000>;
 					opp-level = <RPMH_REGULATOR_LEVEL_NOM>;
 					opp-peak-kBps = <8171875>;
+					opp-supported-hw = <0x2>;
 				};
 
 				opp-778000000 {
 					opp-hz = /bits/ 64 <778000000>;
 					opp-level = <RPMH_REGULATOR_LEVEL_TURBO>;
 					opp-peak-kBps = <10687500>;
+					opp-supported-hw = <0x1>;
 				};
 
 				opp-800000000 {
 					opp-hz = /bits/ 64 <800000000>;
 					opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L1>;
 					opp-peak-kBps = <12484375>;
+					opp-supported-hw = <0x1>;
 				};
 			};
 		};


### PR DESCRIPTION
Add gpu and gmu nodes for sa8775p chipset. As of now all SKUs have the same GPU fmax, so there is no requirement of speed bin support.

Link: https://lore.kernel.org/all/20250822-a663-gpu-support-v4-3-97d26bb2144e@oss.qualcomm.com/


Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>