### PR TITLE
FROMLIST: drm/msm/adreno: Add a modparam to skip GPU

### DIFF
--- a/drivers/gpu/drm/msm/adreno/adreno_device.c
+++ b/drivers/gpu/drm/msm/adreno/adreno_device.c
@@ -24,6 +24,10 @@ bool disable_acd;
 MODULE_PARM_DESC(disable_acd, "Forcefully disable GPU ACD");
 module_param_unsafe(disable_acd, bool, 0400);
 
+static bool skip_gpu;
+MODULE_PARM_DESC(no_gpu, "Disable GPU driver register (0=enable GPU driver register (default), 1=skip GPU driver register");
+module_param(skip_gpu, bool, 0400);
+
 extern const struct adreno_gpulist a2xx_gpulist;
 extern const struct adreno_gpulist a3xx_gpulist;
 extern const struct adreno_gpulist a4xx_gpulist;
@@ -183,6 +187,9 @@ bool adreno_has_gpu(struct device_node *node)
 	const struct adreno_info *info;
 	uint32_t chip_id;
 	int ret;
+
+	if (skip_gpu)
+		return false;
 
 	ret = find_chipid(node, &chip_id);
 	if (ret)
@@ -404,10 +411,16 @@ static struct platform_driver adreno_driver = {
 
 void __init adreno_register(void)
 {
+	if (skip_gpu)
+		return;
+
 	platform_driver_register(&adreno_driver);
 }
 
 void __exit adreno_unregister(void)
 {
+	if (skip_gpu)
+		return;
+
 	platform_driver_unregister(&adreno_driver);
 }


### PR DESCRIPTION
During bringup of a new GPU support, it is convenient to have knob to quickly disable GPU, but keep the display support. This helps to fallback to 'kms_swrast' in case of bootup issues due to GPU. Add a modparam to support this.

Link: https://lore.kernel.org/all/20250911-assorted-sept-1-v2-3-a8bf1ee20792@oss.qualcomm.com/
Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>