### PR TITLE
FROMLIST: arm64: dts: qcom: qcs615-ride: Set drive strength for wlan-en-state pin

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+++ b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
@@ -397,6 +397,7 @@
 	wlan_en_state: wlan-en-state {
 		pins = "gpio98";
 		function = "gpio";
+		drive-strength = <16>;
 		bias-pull-down;
 		output-low;
 	};


### PR DESCRIPTION
Set the drive-strength to 16mA for gpio98 used as wlan-en-state in the QCS615 ride platform device tree. This ensures sufficient output strength for controlling the WLAN enable signal reliably.

Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
Link: https://lore.kernel.org/all/20250918112729.3512516-1-yu.zhang@oss.qualcomm.com/