### PR TITLE
FROMLIST: arm64: dts: qcom: lemans-evk: Add PSCI SYSTEM_RESET2 types

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -595,6 +595,13 @@
 	status = "okay";
 };
 
+&psci {
+	reboot-mode {
+		mode-bootloader = <0x10001 0x2>;
+		mode-edl = <0 0x1>;
+	};
+};
+
 &qupv3_id_0 {
 	status = "okay";
 };


### PR DESCRIPTION
Add support for SYSTEM_RESET2 vendor-specific resets in lemans-evk as reboot-modes.  Describe the resets:
"bootloader" will cause device to reboot and stop in the bootloader's fastboot mode.  "edl" will cause device to reboot into "emergency download mode", which permits loading images via the Firehose protocol.

Link: https://lore.kernel.org/r/20250922-arm-psci-system_reset2-vendor-reboots-v15-11-7ce3a08878f1@oss.qualcomm.com