### PR TITLE
 FROMLIST: dt-bindings: PCI: qcom,pcie-x1e80100: Set clocks minItems for the fif…

### DIFF
--- a/Documentation/devicetree/bindings/pci/qcom,pcie-x1e80100.yaml
+++ b/Documentation/devicetree/bindings/pci/qcom,pcie-x1e80100.yaml
@@ -32,10 +32,11 @@ properties:
       - const: mhi # MHI registers
 
   clocks:
-    minItems: 7
+    minItems: 6
     maxItems: 7
 
   clock-names:
+    minItems: 6
     items:
       - const: aux # Auxiliary clock
       - const: cfg # Configuration clock


### PR DESCRIPTION
…th Glymur PCIe Controller

On the Qualcomm Glymur platform, the fifth PCIe host is compatible with the DWC controller present on the X1E80100 platform, but does not have cnoc_sf_axi clock. Hence, set minItems of clocks and clock-names to six.



Acked-by: Rob Herring (Arm) <robh@kernel.org>