### PR TITLE
PENDING: nvme-pci: fix race condition in dma_need_unmap

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -780,7 +780,7 @@ static bool nvme_pci_prp_iter_next(struct request *req, struct device *dma_dev,
 		return true;
 	if (!blk_rq_dma_map_iter_next(req, dma_dev, &iod->dma_state, iter))
 		return false;
-	if (!dma_use_iova(&iod->dma_state) && dma_need_unmap(dma_dev)) {
+	if (iod->dma_vecs && !dma_use_iova(&iod->dma_state) && dma_need_unmap(dma_dev)) {
 		iod->dma_vecs[iod->nr_dma_vecs].addr = iter->addr;
 		iod->dma_vecs[iod->nr_dma_vecs].len = iter->len;
 		iod->nr_dma_vecs++;


### PR DESCRIPTION
The nvme_pci_prp_iter_next function had a race condition where dma_need_unmap() could return true indicating DMA unmapping is needed, but iod->dma_vecs was NULL, causing a NULL pointer dereference.

This occurred because:
1. dma_vecs allocation happens in nvme_pci_setup_data_prp()
2. nvme_pci_prp_iter_next() checks dma_need_unmap() but doesn't verify if dma_vecs allocation was successful
3. If allocation failed or race condition occurred, accessing dma_vecs[0] would cause kernel crash

The crash manifested as:
- dma_size:0 unmap:0 initially, then dma_size:0 unmap:1
- nr_dma_vecs:0 dma_vecs:0x0 (NULL pointer)
- Unable to handle kernel NULL pointer dereference at virtual address 0x0.

Fix by adding iod->dma_vecs NULL check to the condition in nvme_pci_prp_iter_next(), ensuring DMA vector operations only occur when the dma_vecs array has been successfully allocated.