### PR TITLE
QCLINUX: Revert "arm64: dts: qcom: sm8750-mtp: Add WiFi and Bluetooth"

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8750-mtp.dts
+++ b/arch/arm64/boot/dts/qcom/sm8750-mtp.dts
@@ -201,74 +201,6 @@
 		regulator-always-on;
 		regulator-boot-on;
 	};
-
-	/*
-	 * MTPs rev 2.0 (power grid v8) come with two different WiFi chips:
-	 * WCN7850 and WCN786x.
-	 * Device nodes here for the PMU, WiFi and Bluetooth describe the MTP
-	 * variant with WCN7850.
-	 */
-	wcn7850-pmu {
-		compatible = "qcom,wcn7850-pmu";
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&wlan_en>, <&bt_default>;
-
-		wlan-enable-gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
-		bt-enable-gpios = <&pm8550ve_f_gpios 3 GPIO_ACTIVE_HIGH>;
-
-		vdd-supply = <&vreg_s5f_0p85>;
-		vddio-supply = <&vreg_l3f_1p8>;
-		vddio1p2-supply = <&vreg_l2f_1p2>;
-		vddaon-supply = <&vreg_s4d_0p85>;
-		vdddig-supply = <&vreg_s1d_0p97>;
-		vddrfa1p2-supply = <&vreg_s7i_1p2>;
-		vddrfa1p8-supply = <&vreg_s3g_1p8>;
-
-		clocks = <&rpmhcc RPMH_RF_CLK1>;
-
-		regulators {
-			vreg_pmu_rfa_cmn: ldo0 {
-				regulator-name = "vreg_pmu_rfa_cmn";
-			};
-
-			vreg_pmu_aon_0p59: ldo1 {
-				regulator-name = "vreg_pmu_aon_0p59";
-			};
-
-			vreg_pmu_wlcx_0p8: ldo2 {
-				regulator-name = "vreg_pmu_wlcx_0p8";
-			};
-
-			vreg_pmu_wlmx_0p85: ldo3 {
-				regulator-name = "vreg_pmu_wlmx_0p85";
-			};
-
-			vreg_pmu_btcmx_0p85: ldo4 {
-				regulator-name = "vreg_pmu_btcmx_0p85";
-			};
-
-			vreg_pmu_rfa_0p8: ldo5 {
-				regulator-name = "vreg_pmu_rfa_0p8";
-			};
-
-			vreg_pmu_rfa_1p2: ldo6 {
-				regulator-name = "vreg_pmu_rfa_1p2";
-			};
-
-			vreg_pmu_rfa_1p8: ldo7 {
-				regulator-name = "vreg_pmu_rfa_1p8";
-			};
-
-			vreg_pmu_pcie_0p9: ldo8 {
-				regulator-name = "vreg_pmu_pcie_0p9";
-			};
-
-			vreg_pmu_pcie_1p8: ldo9 {
-				regulator-name = "vreg_pmu_pcie_1p8";
-			};
-		};
-	};
 };
 
 &apps_rsc {
@@ -494,7 +426,7 @@
 
 		vreg_s4d_0p85: smps4 {
 			regulator-name = "vreg_s4d_0p85";
-			regulator-min-microvolt = <852000>;
+			regulator-min-microvolt = <500000>;
 			regulator-max-microvolt = <1036000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 		};
@@ -540,9 +472,9 @@
 
 		qcom,pmic-id = "f";
 
-		vreg_s5f_0p85: smps5 {
-			regulator-name = "vreg_s5f_0p85";
-			regulator-min-microvolt = <852000>;
+		vreg_s5f_0p5: smps5 {
+			regulator-name = "vreg_s5f_0p5";
+			regulator-min-microvolt = <500000>;
 			regulator-max-microvolt = <1000000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 		};
@@ -959,40 +891,6 @@
 	status = "okay";
 };
 
-&pcie0 {
-	wake-gpios = <&tlmm 104 GPIO_ACTIVE_HIGH>;
-	perst-gpios = <&tlmm 102 GPIO_ACTIVE_LOW>;
-
-	pinctrl-0 = <&pcie0_default_state>;
-	pinctrl-names = "default";
-
-	status = "okay";
-};
-
-&pcie0_phy {
-	vdda-phy-supply = <&vreg_l1f_0p88>;
-	vdda-pll-supply = <&vreg_l3g_1p2>;
-
-	status = "okay";
-};
-
-&pcieport0 {
-	wifi@0 {
-		compatible = "pci17cb,1107";
-		reg = <0x10000 0x0 0x0 0x0 0x0>;
-
-		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
-		vddaon-supply = <&vreg_pmu_aon_0p59>;
-		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
-		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
-		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
-		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
-		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
-		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
-		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
-	};
-};
-
 &pmih0108_eusb2_repeater {
 	status = "okay";
 
@@ -1001,10 +899,6 @@
 };
 
 &qupv3_1 {
-	status = "okay";
-};
-
-&qupv3_2 {
 	status = "okay";
 };
 
@@ -1141,45 +1035,12 @@
 };
 
 &tlmm {
-	bt_default: bt-default-state {
-		sw-ctrl-pins {
-			pins = "gpio18";
-			function = "gpio";
-			bias-pull-down;
-		};
-	};
-
 	wcd_default: wcd-reset-n-active-state {
 		pins = "gpio101";
 		function = "gpio";
 		drive-strength = <16>;
 		bias-disable;
 		output-low;
-	};
-
-	wlan_en: wlan-en-state {
-		pins = "gpio16";
-		function = "gpio";
-		drive-strength = <8>;
-		bias-pull-down;
-	};
-};
-
-&uart14 {
-	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn7850-bt";
-
-		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
-		vddaon-supply = <&vreg_pmu_aon_0p59>;
-		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
-		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
-		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
-		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
-		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
-
-		max-speed = <3200000>;
 	};
 };
 


### PR DESCRIPTION
This reverts commit 141714e163bbb7620d538af48fce4024a4f239e1 due to bootup crash observed on the Pakala MTP device.

Refer to GitHub issue: https://github.com/qualcomm-linux/kernel/issues/81