### PR TITLE
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add firmware-name to QUP…

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -1144,10 +1144,12 @@
 };
 
 &qupv3_id_0 {
+	firmware-name = "qcom/qcs6490/qupv3fw.elf";
 	status = "okay";
 };
 
 &qupv3_id_1 {
+	firmware-name = "qcom/qcs6490/qupv3fw.elf";
 	status = "okay";
 };
 


### PR DESCRIPTION
…v3 nodes

Traditionally, firmware loading for Serial Engines (SE) in the QUP hardware of Qualcomm SoCs has been managed by TrustZone (TZ). While this approach ensures secure SE assignment and access control, it limits flexibility for developers who need to enable various protocols on different SEs.

Add the firmware-name property to QUPv3 nodes in the device tree to enable firmware loading from the Linux environment. Handle SE assignments and access control permissions directly within Linux, removing the dependency on TrustZone.

Link: https://lore.kernel.org/all/20250923161107.3541698-1-viken.dadhaniya@oss.qualcomm.com/

Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>