### PR TITLE
PENDING: arm64: dts: qcom: Enable tpm support for hamoa-iot

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
@@ -905,6 +905,21 @@
 	vdd3-supply = <&vreg_l8b_3p0>;
 };
 
+&spi11 {
+       pinctrl-0 = <&qup_spi11_data_clk>, <&qup_spi11_cs>;
+       pinctrl-names = "default";
+       status = "okay";
+
+       st33htpm0: st33htpm@0 {
+               compatible = "st,st33htpm-spi";
+               reg = <0>;
+               spi-max-frequency = <20000000>;
+               #address-cells = <1>;
+               #size-cells = <0>;
+               status = "okay";
+       };
+};
+
 &swr0 {
 	status = "okay";
 


### PR DESCRIPTION
Enable tpm to communicate over spi through gpio for hamoa-iot.