### PR TITLE
Dependencies Required for Kaanapali on PDC

### DIFF
--- a/Documentation/devicetree/bindings/interrupt-controller/qcom,pdc.yaml
+++ b/Documentation/devicetree/bindings/interrupt-controller/qcom,pdc.yaml
@@ -27,6 +27,7 @@ properties:
     items:
       - enum:
           - qcom,glymur-pdc
+          - qcom,kaanapali-pdc
           - qcom,qcs615-pdc
           - qcom,qcs8300-pdc
           - qcom,qdu1000-pdc


### PR DESCRIPTION
…roller

Add a compatible for the Power Domain Controller on Kaanapali platforms.


Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>

Link: https://lore.kernel.org/all/20251021-knp-pdc-v2-1-a38767f5bb8e@oss.qualcomm.com/