### PR TITLE
Fromlist: arm64: dts: qcom: hamoa-iot-som: Unreserve GPIOs blocking S…

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-som.dtsi
@@ -451,8 +451,7 @@
 };
 
 &tlmm {
-	gpio-reserved-ranges = <34 2>, /* TPM LP & INT */
-			       <44 4>; /* SPI (TPM) */
+	gpio-reserved-ranges = <34 2>; /* TPM LP & INT */
 
 	pcie4_default: pcie4-default-state {
 		clkreq-n-pins {


### PR DESCRIPTION
…PI11 access

GPIOs 44-47 were previously reserved, preventing Linux from accessing SPI11 (qupv1_se3). Since there is no TZ use case for these pins on Linux, they can be safely unreserved. Removing them from the reserved list resolves the SPI11 access issue for Linux.

Link: https://lore.kernel.org/linux-arm-msm/20251106102448.3585332-1-xueyao.an@oss.qualcomm.com/