### PR TITLE
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: Enable TPM (ST33) on SPI11

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
@@ -960,6 +960,16 @@
 	vdd3-supply = <&vreg_l8b_3p0>;
 };
 
+&spi11 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &swr0 {
 	status = "okay";
 


### PR DESCRIPTION
Enable ST33HTPM TPM over SPI11 on the Hamoa IoT EVK by adding the required SPI and TPM nodes.

Link: https://lore.kernel.org/all/20251112-arm64-dts-qcom-hamoa-iot-evk-enable-st33-tpm-on-spi11-v3-1-39b19eb55cc3@oss.qualcomm.com/