### PR TITLE
FROMLIST: arm64: dts: qcom: lemans-evk: Enable TPM (ST33)

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -647,6 +647,16 @@
 	status = "okay";
 };
 
+&spi16 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &sdhc {
 	vmmc-supply = <&vmmc_sdc>;
 	vqmmc-supply = <&vreg_sdc>;


### PR DESCRIPTION
Enable ST33HTPM TPM over SPI16 on the LeMans IoT EVK by adding the required SPI and TPM nodes.

Link: https://lore.kernel.org/all/20251114-enable-tpm-lemans-v1-1-c8d8b580ace7@oss.qualcomm.com/