### PR TITLE
FROMLIST: arm64: dts: qcom: monaco-evk: Enable TPM (ST33)

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -441,6 +441,16 @@
 	status = "okay";
 };
 
+&spi10 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &tlmm {
 	ethernet0_default: ethernet0-default-state {
 		ethernet0_mdc: ethernet0-mdc-pins {


### PR DESCRIPTION
Enable ST33HTPM TPM over SPI10 on the Monaco IoT EVK by adding the required SPI and TPM nodes.

Link: https://lore.kernel.org/all/20251114-enable-tpm-monaco-v1-1-4ed566838698@oss.qualcomm.com/