### PR TITLE
dt-bindings: usb: Add binding for Genesys Logic GL3590 hub

### DIFF
--- a/Documentation/devicetree/bindings/usb/genesys,gl850g.yaml
+++ b/Documentation/devicetree/bindings/usb/genesys,gl850g.yaml
@@ -15,6 +15,7 @@ properties:
       - usb5e3,608
       - usb5e3,610
       - usb5e3,620
+      - usb5e3,625
       - usb5e3,626
 
   reg: true
@@ -68,6 +69,17 @@ allOf:
       properties:
         peer-hub: true
         vdd-supply: true
+
+  - if:
+      properties:
+        compatible:
+          contains:
+            enum:
+              - usb5e3,625
+    then:
+      properties:
+        peer-hub: true
+        vdd-supply: false
 
 unevaluatedProperties: false
 


### PR DESCRIPTION
Add the binding for the USB3.2 Genesys Logic GL3590 hub.