### PR TITLE
FROMLIST: arm64: dts: qcom: lemans-evk: Enable wakeup for primary USB…

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -589,6 +589,8 @@
 		pinctrl-0 = <&usb_id>, <&usb0_intr_state>;
 		pinctrl-names = "default";
 
+		wakeup-source;
+
 		ports {
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
Add the "wakeup-source" property to the primary port controller node so its interrupt can wake the system from low‑power states on lemans EVK platform.

CRs-Fixed: 4399120

