### PR TITLE
WORKAROUND: PCI: Disable L1ss through quirk for HMT & Cologne

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -8471,8 +8471,7 @@
 			     <GIC_SPI 143 IRQ_TYPE_LEVEL_HIGH>,
 			     <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>,
 			     <GIC_SPI 145 IRQ_TYPE_LEVEL_HIGH>,
-			     <GIC_SPI 146 IRQ_TYPE_LEVEL_HIGH>,
-			     <GIC_SPI 518 IRQ_TYPE_LEVEL_HIGH>;
+			     <GIC_SPI 146 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-names = "msi0",
 				  "msi1",
 				  "msi2",
@@ -8480,8 +8479,7 @@
 				  "msi4",
 				  "msi5",
 				  "msi6",
-				  "msi7",
-				  "global";
+				  "msi7";
 		#interrupt-cells = <1>;
 		interrupt-map-mask = <0 0 0 0x7>;
 		interrupt-map = <0 0 0 1 &intc GIC_SPI 148 IRQ_TYPE_LEVEL_HIGH>,

--- a/drivers/base/dd.c
+++ b/drivers/base/dd.c
@@ -258,7 +258,7 @@ static int deferred_devs_show(struct seq_file *s, void *data)
 DEFINE_SHOW_ATTRIBUTE(deferred_devs);
 
 #ifdef CONFIG_MODULES
-static int driver_deferred_probe_timeout = 10;
+static int driver_deferred_probe_timeout = 15;
 #else
 static int driver_deferred_probe_timeout;
 #endif

--- a/drivers/firmware/qcom/qcom_scm.c
+++ b/drivers/firmware/qcom/qcom_scm.c
@@ -2208,6 +2208,51 @@ bool qcom_scm_is_available(void)
 }
 EXPORT_SYMBOL_GPL(qcom_scm_is_available);
 
+int qcom_scm_camera_update_camnoc_qos(uint32_t use_case_id,
+	uint32_t cam_qos_cnt, struct qcom_scm_camera_qos *cam_qos)
+{
+	int ret;
+	dma_addr_t payload_phys;
+	u32 *payload_buf = NULL;
+	u32 payload_size = 0;
+
+	if ((cam_qos_cnt > QCOM_SCM_CAMERA_MAX_QOS_CNT) || (cam_qos_cnt && !cam_qos)) {
+		pr_err("Invalid input SmartQoS count: %d\n", cam_qos_cnt);
+		return -EINVAL;
+	}
+
+	struct qcom_scm_desc desc = {
+		.svc = QCOM_SCM_SVC_CAMERA,
+		.cmd = QCOM_SCM_CAMERA_UPDATE_CAMNOC_QOS,
+		.owner = ARM_SMCCC_OWNER_SIP,
+		.args[0] = use_case_id,
+		.args[2] = payload_size,
+		.arginfo = QCOM_SCM_ARGS(3, QCOM_SCM_VAL, QCOM_SCM_RW, QCOM_SCM_VAL),
+	};
+
+	payload_size = cam_qos_cnt * sizeof(struct qcom_scm_camera_qos);
+
+	/* fill all required qos settings */
+	if (use_case_id && payload_size && cam_qos) {
+		payload_buf = dma_alloc_coherent(__scm->dev,
+						 payload_size, &payload_phys, GFP_KERNEL);
+		if (!payload_buf)
+			return -ENOMEM;
+
+		memcpy(payload_buf, cam_qos, payload_size);
+		desc.args[1] = payload_phys;
+		desc.args[2] = payload_size;
+
+	}
+	ret = qcom_scm_call(__scm->dev, &desc, NULL);
+
+	if (payload_buf)
+		dma_free_coherent(__scm->dev, payload_size, payload_buf, payload_phys);
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(qcom_scm_camera_update_camnoc_qos);
+
 static int qcom_scm_assert_valid_wq_ctx(u32 wq_ctx)
 {
 	/* FW currently only supports a single wq_ctx (zero).

--- a/drivers/firmware/qcom/qcom_scm.h
+++ b/drivers/firmware/qcom/qcom_scm.h
@@ -173,6 +173,9 @@ int qcom_scm_shm_bridge_enable(struct device *scm_dev);
 #define QCOM_SCM_INTERRUPTED	1
 #define QCOM_SCM_WAITQ_SLEEP	2
 
+#define QCOM_SCM_SVC_CAMERA                     0x18
+#define QCOM_SCM_CAMERA_UPDATE_CAMNOC_QOS       0xA
+
 static inline int qcom_scm_remap_error(int err)
 {
 	switch (err) {

--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2527,6 +2527,12 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_FREESCALE, 0x0451, quirk_disable_aspm_l0s
 DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_PASEMI, 0xa002, quirk_disable_aspm_l0s_l1);
 DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_HUAWEI, 0x1105, quirk_disable_aspm_l0s_l1);
 
+static void quirk_disable_aspm_l1ss(struct pci_dev *dev)
+{
+	pci_disable_link_state(dev, PCIE_LINK_STATE_L1_1 | PCIE_LINK_STATE_L1_2);
+}
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1103, quirk_disable_aspm_l1ss);
+
 /*
  * Some Pericom PCIe-to-PCI bridges in reverse mode need the PCIe Retrain
  * Link bit cleared after starting the link retrain process to allow this

--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2532,6 +2532,8 @@ static void quirk_disable_aspm_l1ss(struct pci_dev *dev)
 	pci_disable_link_state(dev, PCIE_LINK_STATE_L1_1 | PCIE_LINK_STATE_L1_2);
 }
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1103, quirk_disable_aspm_l1ss);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1107, quirk_disable_aspm_l1ss);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1112, quirk_disable_aspm_l1ss);
 
 /*
  * Some Pericom PCIe-to-PCI bridges in reverse mode need the PCIe Retrain

--- a/drivers/ufs/core/ufshcd.c
+++ b/drivers/ufs/core/ufshcd.c
@@ -118,7 +118,7 @@ static bool is_mcq_supported(struct ufs_hba *hba)
 module_param(use_mcq_mode, bool, 0644);
 MODULE_PARM_DESC(use_mcq_mode, "Control MCQ mode for controllers starting from UFSHCI 4.0. 1 - enable MCQ, 0 - disable MCQ. MCQ is enabled by default");
 
-static unsigned int uic_cmd_timeout = UIC_CMD_TIMEOUT_DEFAULT;
+static unsigned int uic_cmd_timeout = UIC_CMD_TIMEOUT_MAX;
 
 static int uic_cmd_timeout_set(const char *val, const struct kernel_param *kp)
 {

--- a/include/dt-bindings/mailbox/qcom-ipcc.h
+++ b/include/dt-bindings/mailbox/qcom-ipcc.h
@@ -36,4 +36,52 @@
 #define IPCC_CLIENT_GPDSP0		31
 #define IPCC_CLIENT_GPDSP1		32
 
+/* Physical client IDs */
+#define IPCC_MPROC_AOP                  0
+#define IPCC_MPROC_TZ                   1
+#define IPCC_MPROC_MPSS                 2
+#define IPCC_MPROC_LPASS                3
+#define IPCC_MPROC_SDC                  4
+#define IPCC_MPROC_CDSP                 5
+#define IPCC_MPROC_APSS                 6
+#define IPCC_MPROC_SOCCP                13
+#define IPCC_MPROC_DCP                  14
+#define IPCC_MPROC_SPSS                 15
+#define IPCC_MPROC_TME                  16
+
+#define IPCC_COMPUTE_L0_CDSP            2
+#define IPCC_COMPUTE_L0_APSS            3
+#define IPCC_COMPUTE_L0_GPU             4
+#define IPCC_COMPUTE_L0_CVP             8
+#define IPCC_COMPUTE_L0_CAM             9
+#define IPCC_COMPUTE_L0_CAM1            10
+#define IPCC_COMPUTE_L0_DCP             11
+#define IPCC_COMPUTE_L0_VPU             12
+#define IPCC_COMPUTE_L0_SOCCP           16
+
+#define IPCC_COMPUTE_L1_CDSP            2
+#define IPCC_COMPUTE_L1_APSS            3
+#define IPCC_COMPUTE_L1_GPU             4
+#define IPCC_COMPUTE_L1_CVP             8
+#define IPCC_COMPUTE_L1_CAM             9
+#define IPCC_COMPUTE_L1_CAM1            10
+#define IPCC_COMPUTE_L1_DCP             11
+#define IPCC_COMPUTE_L1_VPU             12
+#define IPCC_COMPUTE_L1_SOCCP           16
+
+#define IPCC_PERIPH_CDSP                2
+#define IPCC_PERIPH_APSS                3
+#define IPCC_PERIPH_PCIE0               4
+#define IPCC_PERIPH_PCIE1               5
+
+#define IPCC_FENCE_CDSP                 2
+#define IPCC_FENCE_APSS                 3
+#define IPCC_FENCE_GPU                  4
+#define IPCC_FENCE_CVP                  8
+#define IPCC_FENCE_CAM                  8
+#define IPCC_FENCE_VPU                  20
+#define IPCC_FENCE_SOCCP                24
+#define IPCC_FENCE_CAM1                 10
+#define IPCC_FENCE_DCP                  11
+
 #endif

--- a/include/linux/firmware/qcom/qcom_scm.h
+++ b/include/linux/firmware/qcom/qcom_scm.h
@@ -10,10 +10,12 @@
 #include <linux/cpumask.h>
 
 #include <dt-bindings/firmware/qcom,scm.h>
+#include <asm-generic/errno-base.h>
 
 #define QCOM_SCM_VERSION(major, minor)	(((major) << 16) | ((minor) & 0xFF))
 #define QCOM_SCM_CPU_PWR_DOWN_L2_ON	0x0
 #define QCOM_SCM_CPU_PWR_DOWN_L2_OFF	0x1
+#define QCOM_SCM_CAMERA_MAX_QOS_CNT	2
 #define QCOM_SCM_HDCP_MAX_REQ_CNT	5
 
 struct qcom_scm_hdcp_req {
@@ -71,6 +73,15 @@ struct qcom_scm_pas_metadata {
 	dma_addr_t phys;
 	ssize_t size;
 };
+
+struct qcom_scm_camera_qos {
+	u32 offset;
+	u32 val;
+};
+
+int qcom_scm_camera_update_camnoc_qos(uint32_t use_case_id,
+		uint32_t qos_cnt, struct qcom_scm_camera_qos *scm_buf);
+
 
 int qcom_scm_pas_init_image(u32 peripheral, const void *metadata, size_t size,
 			    struct qcom_scm_pas_metadata *ctx);


### PR DESCRIPTION
When PCIe L1ss is enabled, WLAN functionality is completly broken. There are some connectivity issues in this platform mostly with CLKREQ# pin.

Disable L1ss as workaround untill actual issue get resolved.