### PR TITLE
QCLINUX: arm64: dts: qcom: add labels to sensor DTSI

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
@@ -125,7 +125,7 @@
 	};
 
 	/*cam0a-ov9282*/
-	qcom,cam-sensor1 {
+	rb8_slot0: qcom,cam-sensor1 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <0>;
 		sensor-position-roll = <0>;
@@ -439,7 +439,7 @@
 	};
 
 	/*cam1-ov9282*/
-	qcom,cam-sensor21 {
+	rb8_slot1: qcom,cam-sensor21 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <1>;
 		sensor-position-roll = <0>;
@@ -755,7 +755,7 @@
 	};
 
 	/*cam2-ov9282*/
-	qcom,cam-sensor22 {
+	rb8_slot2: qcom,cam-sensor22 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <2>;
 		sensor-position-roll = <0>;
@@ -994,7 +994,7 @@
 	};
 
 	/*cam3-ov9282*/
-	qcom,cam-sensor23 {
+	rb8_slot3: qcom,cam-sensor23 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <3>;
 		sensor-position-roll = <0>;

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-camera-sensor.dtsi
@@ -55,7 +55,7 @@
 	};
 
 	/*cam0a-ov9282*/
-	qcom,cam-sensor1 {
+	rb3_slot0a: qcom,cam-sensor1 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <1>;
 		csiphy-sd-index = <0>;
@@ -92,7 +92,7 @@
 	};
 
 	/*cam1-ov9282*/
-	qcom,cam-sensor6 {
+	rb3_slot1: qcom,cam-sensor6 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <6>;
 		csiphy-sd-index = <1>;
@@ -254,7 +254,7 @@
 	};
 
 	/*cam3-imx577*/
-	qcom,cam-sensor0 {
+	rb3_slot3: qcom,cam-sensor0 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <0>;
 		csiphy-sd-index = <3>;
@@ -345,7 +345,7 @@
 	};
 
 	/*cam0b-ov9282*/
-	qcom,cam-sensor7 {
+	rb3_slot0b: qcom,cam-sensor7 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <7>;
 		csiphy-sd-index = <0>;
@@ -383,7 +383,7 @@
 	};
 
 	/*cam2-imx577*/
-	qcom,cam-sensor8 {
+	rb3_slot2: qcom,cam-sensor8 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <8>;
 		csiphy-sd-index = <2>;


### PR DESCRIPTION
Add DT labels to sensor nodes in the Lemans and Kodiak DTSI files to enable phandle references.
Monaco changes are already handled.