### PR TITLE
WORKAROUND: Revert "PCI: dwc: Remove MSI/MSIX capability for Root Port if iMSI-RX is used as MSI controller"

### DIFF
--- a/drivers/pci/controller/dwc/pcie-designware-host.c
+++ b/drivers/pci/controller/dwc/pcie-designware-host.c
@@ -1165,17 +1165,6 @@ int dw_pcie_setup_rc(struct dw_pcie_rp *pp)
 
 	dw_pcie_dbi_ro_wr_dis(pci);
 
-	/*
-	 * The iMSI-RX module does not support receiving MSI or MSI-X generated
-	 * by the Root Port. If iMSI-RX is used as the MSI controller, remove
-	 * the MSI and MSI-X capabilities of the Root Port to allow the drivers
-	 * to fall back to INTx instead.
-	 */
-	if (pp->use_imsi_rx) {
-		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSI);
-		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSIX);
-	}
-
 	return 0;
 }
 EXPORT_SYMBOL_GPL(dw_pcie_setup_rc);


### PR DESCRIPTION
commit f5cd8a929c825("PCI: dwc: Remove MSI/MSIX capability for Root Port if iMSI-RX is used as MSI controller") removed MSI & MSIX capability for Root port as dwc controller doesn't support to generate interrupt. Due to this pci framework is falling back to legacy IRQ's.

Now controller can generate to interrupts with legacy IRQ's, and actually causing console flood with PCIe continous AER errorsi, these errors will not cause any functional issues. To avoid these errors revert this temporarly untill actual issue got root caused and fixed.