### PR TITLE
FROMLIST: arm64: dts: qcom: glymur-crd: Add Embedded controller node

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dts
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dts
@@ -641,6 +641,22 @@
 	};
 };
 
+&i2c9 {
+	clock-frequency = <400000>;
+
+	status = "okay";
+
+	embedded-controller@76 {
+		compatible = "qcom,glymur-crd-ec", "qcom,hamoa-crd-ec";
+		reg = <0x76>;
+
+		interrupts-extended = <&tlmm 66 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&ec_int_n_default>;
+		pinctrl-names = "default";
+	};
+};
+
 &mdss {
 	status = "okay";
 };
@@ -924,6 +940,12 @@
 	gpio-reserved-ranges = <4 4>, /* EC TZ Secure I3C */
 			       <10 2>, /* OOB UART */
 			       <44 4>; /* Security SPI (TPM) */
+
+	ec_int_n_default: ec-int-n-state {
+		pins = "gpio66";
+		function = "gpio";
+		bias-disable;
+	};
 
 	edp_bl_en: edp-bl-en-state {
 		pins = "gpio18";


### PR DESCRIPTION
Add embedded controller node for Glymur CRDs which adds fan control, temperature sensors, access to EC state changes through SCI events and suspend entry/exit notifications to the EC.

Link: https://lore.kernel.org/lkml/20260313-v04-add-driver-for-ec-v4-3-ca9d0efd62aa@oss.qualcomm.com/
Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>