### PR TITLE
arm64: dts: qcom: Add RPM GLINK transport for Shikra

### DIFF
--- a/Documentation/devicetree/bindings/mailbox/qcom,apcs-kpss-global.yaml
+++ b/Documentation/devicetree/bindings/mailbox/qcom,apcs-kpss-global.yaml
@@ -65,6 +65,7 @@ properties:
           - qcom,msm8996-apcs-hmss-global
           - qcom,qcm2290-apcs-hmss-global
           - qcom,sdm845-apss-shared
+          - qcom,shikra-apcs-hmss-global
 
   reg:
     maxItems: 1
@@ -238,6 +239,7 @@ allOf:
               - qcom,msm8996-apcs-hmss-global
               - qcom,qcm2290-apcs-hmss-global
               - qcom,sdm845-apss-shared
+              - qcom,shikra-apcs-hmss-global
     then:
       properties:
         clocks: false

--- a/Documentation/devicetree/bindings/remoteproc/qcom,rpm-proc.yaml
+++ b/Documentation/devicetree/bindings/remoteproc/qcom,rpm-proc.yaml
@@ -87,6 +87,7 @@ properties:
           - qcom,qcm2290-rpm-proc
           - qcom,qcs404-rpm-proc
           - qcom,sdm660-rpm-proc
+          - qcom,shikra-rpm-proc
           - qcom,sm6115-rpm-proc
           - qcom,sm6125-rpm-proc
           - qcom,sm6375-rpm-proc

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -102,6 +102,17 @@
 		interrupts = <GIC_PPI 5 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
+	rpm: remoteproc {
+		compatible = "qcom,shikra-rpm-proc", "qcom,rpm-proc";
+
+		glink-edge {
+			compatible = "qcom,glink-rpm";
+			interrupts = <GIC_SPI 194 IRQ_TYPE_EDGE_RISING>;
+			qcom,rpm-msg-ram = <&rpm_msg_ram>;
+			mboxes = <&apcs_glb 0>;
+		};
+	};
+
 	reserved_memory: reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -242,6 +253,19 @@
 			};
 		};
 
+		rpm_msg_ram: sram@45f0000 {
+			compatible = "qcom,rpm-msg-ram", "mmio-sram";
+			reg = <0x0 0x045f0000 0x0 0x7000>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0 0x0 0x045f0000 0x7000>;
+
+			apss_mpm: sram@1b8 {
+				reg = <0x1b8 0x48>;
+			};
+		};
+
 		adreno_smmu: iommu@59a0000 {
 			compatible = "qcom,shikra-smmu-500", "qcom,smmu-500", "arm,mmu-500";
 			reg = <0x0 0x059a0000 0x0 0x10000>;
@@ -363,6 +387,12 @@
 			#address-cells = <2>;
 			#size-cells = <2>;
 			ranges;
+		};
+
+		apcs_glb: mailbox@f400000 {
+			compatible = "qcom,shikra-apcs-hmss-global";
+			reg = <0x0 0x0f400000 0x0 0x1000>;
+			#mbox-cells = <1>;
 		};
 
 		timer@f420000 {


### PR DESCRIPTION
Add RPM GLINK transport support for the Shikra platform.                                                                                                                                         
                                                                                                                                                                                                   
  - dt-bindings: mailbox: qcom,apcs-kpss-global: Add Shikra compatible                                                                                                                             
    Adds qcom,shikra-apcs-hmss-global to the APCS mailbox binding to
    avoid undocumented-compatible warnings and keep schema constraints
    aligned.

  - arm64: dts: qcom: Add RPM GLINK transport nodes
    Adds the RPM message RAM region and APCS HMSS global mailbox
    controller, wired up to a rpm-glink node. This enables RPM
    GLINK-based inter-processor communication on Shikra.