### PR TITLE
FROMLIST: driver: bluetooth: hci_qca: disable power control for WCN7850 when bt_en is not defined

### DIFF
--- a/drivers/bluetooth/hci_qca.c
+++ b/drivers/bluetooth/hci_qca.c
@@ -2471,7 +2471,8 @@ static int qca_serdev_probe(struct serdev_device *serdev)
 
 		if (!qcadev->bt_en &&
 		    (data->soc_type == QCA_WCN6750 ||
-		     data->soc_type == QCA_WCN6855))
+		     data->soc_type == QCA_WCN6855 ||
+		     data->soc_type == QCA_WCN7850))
 			power_ctrl_enabled = false;
 
 		qcadev->sw_ctrl = devm_gpiod_get_optional(&serdev->dev, "swctrl",


### PR DESCRIPTION
For platforms where the bt_en GPIO is not defined, software-based power control should be disabled when power is managed by hardware.

Add QCA_WCN7850 to the existing condition so that power_ctrl_enabled is cleared when bt_en is absent, aligning its behavior with WCN6750 and WCN6855.

CRs-Fixed: 4480880