### PR TITLE
QCLINUX: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO

### DIFF
--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
+++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
@@ -432,6 +432,20 @@ static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
 	    reg_node->parent->parent != ctx->of_node)
 		return PWRSEQ_NO_MATCH;
 
+	/*
+	 * If this is a Bluetooth consumer device but the bt-enable GPIO is not
+	 * configured in the power sequencer (e.g. BT_EN is tied high via a
+	 * hardware pull-up and therefore absent from the DT), don't match.
+	 * The consumer driver will fall back to its legacy power control path
+	 * and correctly set power_ctrl_enabled to false.
+	 *
+	 * BT device nodes are conventionally named "bluetooth" in the DT,
+	 * so use of_node_name_eq() as a generic check rather than enumerating
+	 * specific compatible strings.
+	 */
+	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
+		return PWRSEQ_NO_MATCH;
+
 	return PWRSEQ_MATCH_OK;
 }
 


### PR DESCRIPTION
If a Bluetooth consumer device does not have a bt-enable GPIO configured in the power sequencer (for example, when BT_EN is tied high via a hardware pull-up and therefore absent from the DT), the power sequencer should not match the device.

In this case, the Bluetooth consumer driver will fall back to its legacy power control path and correctly set power_ctrl_enabled to false.

Bluetooth device nodes are conventionally named "bluetooth" in the device tree, so use of_node_name_eq() as a generic check instead of enumerating specific compatible strings.

Without this change, Bluetooth over USB does not work.
This is a temporary workaround. Once a proper M.2 binding or solution is upstreamed, both the DTS and driver changes will be reworked and re-submitted according to the M.2 model.

CRs-Fixed: 4480880