### PR TITLE
FROMLIST: arm64: dts: qcom: sm8750-mtp: Set sufficient voltage for panel nt37801

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8750-mtp.dts
+++ b/arch/arm64/boot/dts/qcom/sm8750-mtp.dts
@@ -452,7 +452,7 @@
 
 		vreg_l12b_1p8: ldo12 {
 			regulator-name = "vreg_l12b_1p8";
-			regulator-min-microvolt = <1200000>;
+			regulator-min-microvolt = <1650000>;
 			regulator-max-microvolt = <1800000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 			regulator-allow-set-load;


### PR DESCRIPTION
The NT37801 Sepc V1.0 chapter "5.7.1 Power On Sequence" states
VDDI=1.65V~1.95V, so set sufficient voltage for panel nt37801.

Signed-off-by: Ayushi Makhija <quic_amakhija@quicinc.com>
Link: https://lore.kernel.org/all/20260323102229.1546504-1-quic_amakhija@quicinc.com/

Signed-off-by: Arpit Saini <arpisain@qti.qualcomm.com>
