### PR TITLE
FROMLIST: Revert bypassing PDC wakeup parent for GPIOs

### DIFF
--- a/drivers/pinctrl/qcom/pinctrl-x1e80100.c
+++ b/drivers/pinctrl/qcom/pinctrl-x1e80100.c
@@ -1839,9 +1839,7 @@ static const struct msm_pinctrl_soc_data x1e80100_pinctrl = {
 	.ngroups = ARRAY_SIZE(x1e80100_groups),
 	.ngpios = 239,
 	.wakeirq_map = x1e80100_pdc_map,
-	/* TODO: Enabling PDC currently breaks GPIO interrupts */
-	.nwakeirq_map = 0,
-	/* .nwakeirq_map = ARRAY_SIZE(x1e80100_pdc_map), */
+	.nwakeirq_map = ARRAY_SIZE(x1e80100_pdc_map),
 	.egpio_func = 9,
 };
 


### PR DESCRIPTION
Dependencies:
Depends on PR #832 (https://github.com/qualcomm-linux/kernel-topics/pull/832)
Note to Maintainer: Please do not merge this until #832 is merged.

This reverts commit 602cb14e310a ("pinctrl: qcom: x1e80100: Bypass PDC wakeup parent for now").

PDC interrupts no more break GPIOs. PDC is now set to pass through mode which allows GPIO interrupts to setup as wakeup capable at PDC and pass them to GIC as SPIs. Update nwakeirq_map to reflect the GPIO to PDC irq map size.

Link: https://lore.kernel.org/r/20260312-hamoa_pdc-v1-5-760c8593ce50@oss.qualcomm.com
Signed-off-by: Maulik Shah <maulik.shah@oss.qualcomm.com>
Signed-off-by: Sneh Mankad <sneh.mankad@oss.qualcomm.com>