### PR TITLE
FROMLIST: arm64: dts: qcom: glymur-crd: USB mode change to Host

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dts
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dts
@@ -1096,6 +1096,8 @@
 };
 
 &usb_0 {
+	dr_mode = "host";
+
 	status = "okay";
 };
 
@@ -1125,6 +1127,8 @@
 };
 
 &usb_1 {
+	dr_mode = "host";
+
 	status = "okay";
 };
 


### PR DESCRIPTION
USB mode change to Host

Link: https://lore.kernel.org/linux-arm-msm/20260320-dts-qcom-glymur-add-usb-support-v7-2-ba367eda6010@oss.qualcomm.com/