### PR TITLE
dt-bindings: arm-smmu: Add adreno-smmu compatible for Shikra SoC

### DIFF
--- a/Documentation/devicetree/bindings/iommu/arm,smmu.yaml
+++ b/Documentation/devicetree/bindings/iommu/arm,smmu.yaml
@@ -104,6 +104,7 @@ properties:
               - qcom,sc7280-smmu-500
               - qcom,sc8180x-smmu-500
               - qcom,sc8280xp-smmu-500
+              - qcom,shikra-smmu-500
               - qcom,sm6115-smmu-500
               - qcom,sm6125-smmu-500
               - qcom,sm8150-smmu-500


### PR DESCRIPTION
Qualcomm Shikra SoC implements qcom,smmu-500 for adreno-smmu. Document its corresponding compatible.