### PR TITLE
arm64: dts: qcom: Move rpm_requests in glink-edge node

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -110,6 +110,11 @@
 			interrupts = <GIC_SPI 194 IRQ_TYPE_EDGE_RISING>;
 			qcom,rpm-msg-ram = <&rpm_msg_ram>;
 			mboxes = <&apcs_glb 0>;
+
+			rpm_requests: rpm-requests {
+				compatible = "qcom,rpm-shikra", "qcom,glink-smd-rpm";
+				qcom,glink-channels = "rpm_requests";
+			};
 		};
 
 		mpm: interrupt-controller {
@@ -129,11 +134,6 @@
 					   <86 183>, /* MPM wake, SPMI */
 					   <90 157>, /* QUSB2_PHY DM */
 					   <91 158>; /* QUSB2_PHY DP */
-		};
-
-		rpm_requests: rpm-requests {
-			compatible = "qcom,rpm-shikra", "qcom,glink-smd-rpm";
-			qcom,glink-channels = "rpm_requests";
 		};
 	};
 


### PR DESCRIPTION
Move rpm_requests node to under glink-edge node.

Signed-off-by: Sneh Mankad <sneh.mankad@oss.qualcomm.com>