### PR TITLE
 Enable Qualcomm BCL device for pm8350c and pm7250b

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm7250b.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm7250b.dtsi
@@ -202,6 +202,16 @@
 			interrupt-controller;
 			#interrupt-cells = <2>;
 		};
+
+		sensor@1d00 {
+			compatible = "qcom,pm7250b-bcl", "qcom,bcl-v1";
+			reg = <0x1d00>;
+			interrupts = <PM7250B_SID 0x1d 0x0 IRQ_TYPE_EDGE_RISING>,
+				     <PM7250B_SID 0x1d 0x1 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "bcl-max-min",
+					  "bcl-critical";
+			overcurrent-thresholds-milliamp = <5500 6000>;
+		};
 	};
 
 	pmic@PM7250B_SID1 {

--- a/arch/arm64/boot/dts/qcom/pm8350c.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8350c.dtsi
@@ -41,6 +41,15 @@
 			#pwm-cells = <2>;
 			status = "disabled";
 		};
+
+		sensor@4700 {
+			compatible = "qcom,pm8350c-bcl", "qcom,bcl-v2";
+			reg = <0x4700>;
+			interrupts = <0x2 0x47 0x0 IRQ_TYPE_EDGE_RISING>,
+				     <0x2 0x47 0x1 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "bcl-max-min",
+					  "bcl-critical";
+		};
 	};
 };
 


### PR DESCRIPTION
Enable Qualcomm BCL hardware devicetree binding configuration
for pm8350c and pm7250b.