### PR TITLE
arm64: dts: qcom: shikra: Add TCSR mutex hwlock support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -232,6 +232,8 @@
 			compatible = "qcom,smem";
 			reg = <0x0 0x86000000 0x0 0x200000>;
 			no-map;
+
+			hwlocks = <&tcsr_mutex 3>;
 		};
 
 		audio_heap_mem: audio-heap@86200000 {
@@ -318,6 +320,12 @@
 		#size-cells = <2>;
 		dma-ranges = <0x0 0x0 0x0 0x0 0x10 0x0>;
 		ranges = <0x0 0x0 0x0 0x0 0x10 0x0>;
+
+		tcsr_mutex: syscon@340000 {
+			compatible = "qcom,tcsr-mutex";
+			reg = <0x00340000 0x20000>;
+			#hwlock-cells = <1>;
+		};
 
 		tlmm: pinctrl@500000 {
 			compatible = "qcom,shikra-tlmm";


### PR DESCRIPTION
Describe the TCSR mutex hwlock controller and reference it from the SMEM node to enable proper hardware locking on Shikra.