### PR TITLE
arm64: dts: qcom: shikra: Add download mode support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -110,6 +110,15 @@
 		};
 	};
 
+	firmware {
+		scm {
+			compatible = "qcom,scm-shikra", "qcom,scm";
+			qcom,dload-mode = <&tcsr_regs 0x2000>;
+			interconnects = <&system_noc MASTER_CRYPTO_CORE0 RPM_ALWAYS_TAG
+					 &mc_virt SLAVE_EBI_CH0 RPM_ALWAYS_TAG>;
+		};
+	};
+
 	memory@a0000000 {
 		device_type = "memory";
 		/* We expect the bootloader to fill in the size */
@@ -327,6 +336,11 @@
 			compatible = "qcom,tcsr-mutex";
 			reg = <0x0 0x00340000 0x0 0x20000>;
 			#hwlock-cells = <1>;
+		};
+
+		tcsr_regs: syscon@3c0000 {
+			compatible = "qcom,shikra-tcsr", "syscon";
+			reg = <0x0 0x003c0000 0x0 0x40000>;
 		};
 
 		tlmm: pinctrl@500000 {


### PR DESCRIPTION
Add the SCM firmware node and TCSR syscon required to support download mode on Shikra.