### PR TITLE
FROMLIST: arm64: dts: qcom: monaco-evk: enable UART6 for robot board

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -22,6 +22,7 @@
 		i2c1 = &i2c1;
 		serial0 = &uart7;
 		serial1 = &uart2;
+		serial2 = &uart6;
 	};
 
 	chosen {
@@ -935,6 +936,10 @@
 		vddrfa1p2-supply = <&vreg_wcn_3p3>;
 		vddrfa1p8-supply = <&vreg_wcn_3p3>;
 	};
+};
+
+&uart6 {
+	status = "okay";
 };
 
 &uart7 {


### PR DESCRIPTION
The monaco-evk mezzanine connector supports a robot expansion board that requires UART6, which is currently disabled. This prevents the expansion board from exchanging data and control commands.

Enable UART6 and assign the serial2 alias to provide stable device enumeration for the expansion board.

Link: https://lore.kernel.org/all/20260327083101.1343613-3-canfeng.zhuang@oss.qualcomm.com/

CRs-Fixed: 4490366