### PR TITLE
FROMLIST: arm64: dts: qcom: lemans-evk: enable UART0 for robot board

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -22,6 +22,7 @@
 		mmc1 = &sdhc;
 		serial0 = &uart10;
 		serial1 = &uart17;
+		serial2 = &uart0;
 	};
 
 	dmic: audio-codec-0 {
@@ -1071,6 +1072,10 @@
 		function = "gpio";
 		bias-pull-up;
 	};
+};
+
+&uart0 {
+	status = "okay";
 };
 
 &uart10 {


### PR DESCRIPTION
The lemans-evk mezzanine connector supports a robot expansion board that requires UART0, which is currently disabled. This prevents the expansion board from exchanging data and control commands.

Enable UART0 and assign the serial2 alias to provide stable device enumeration for the expansion board.

Link: https://lore.kernel.org/all/20260327083101.1343613-2-canfeng.zhuang@oss.qualcomm.com/

CRs-Fixed: 4490366