### PR TITLE
Fix ICE reg size on Kodiak and SM8450 dts

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak.dtsi
+++ b/arch/arm64/boot/dts/qcom/kodiak.dtsi
@@ -2587,7 +2587,7 @@
 		ice: crypto@1d88000 {
 			compatible = "qcom,sc7280-inline-crypto-engine",
 				     "qcom,inline-crypto-engine";
-			reg = <0 0x01d88000 0 0x8000>;
+			reg = <0 0x01d88000 0 0x18000>;
 			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
 				 <&gcc GCC_UFS_PHY_AHB_CLK>;
 			clock-names = "ice_core_clk",

--- a/arch/arm64/boot/dts/qcom/sm8450.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8450.dtsi
@@ -5373,7 +5373,7 @@
 		ice: crypto@1d88000 {
 			compatible = "qcom,sm8450-inline-crypto-engine",
 				     "qcom,inline-crypto-engine";
-			reg = <0 0x01d88000 0 0x8000>;
+			reg = <0 0x01d88000 0 0x18000>;
 			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
 				 <&gcc GCC_UFS_PHY_AHB_CLK>;
 			clock-names = "ice_core_clk",


### PR DESCRIPTION
Update ICE reg size for kodiak and sm8450.

Ice reg size for kodiak/sm8450 is currently written incorrectly and
doesn't match hardware specification. This series attempt to fix it.

CR details: CR4496879