### PR TITLE
PENDING: arm64: qcom: dts: talos: add TGU device in staging dtso

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -361,6 +361,7 @@ talos-evk-lvds-auo,g133han01-dtbs	:= \
 	talos-evk.dtb talos-evk-lvds-auo,g133han01.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-camera-imx577.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-lvds-auo,g133han01.dtb
+dtbo-$(CONFIG_ARCH_QCOM)	+= talos-staging.dtbo
 x1e001de-devkit-el2-dtbs	:= x1e001de-devkit.dtb x1-el2.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= x1e001de-devkit.dtb x1e001de-devkit-el2.dtb
 x1e78100-lenovo-thinkpad-t14s-el2-dtbs	:= x1e78100-lenovo-thinkpad-t14s.dtb x1-el2.dtbo

--- a/arch/arm64/boot/dts/qcom/talos-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/talos-staging.dtso
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * Talos staging overlay - add staging-specific device tree modifications here.
+ */
+
+/dts-v1/;
+/plugin/;
+
+&soc {
+	tgu@6b0c000 {
+		compatible = "qcom,tgu", "arm,primecell";
+		reg = <0x0 0x6b0c000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+	};
+};


### PR DESCRIPTION
Add TGU device for supporting IPCB feature in staging dtso file.