### PR TITLE
WORKAROUND: arm64: dts: qcom: monaco-evk: Use refgen regulator for us…

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -1079,7 +1079,7 @@
 };
 
 &usb_2_hsphy {
-	vdda-pll-supply = <&vreg_l7a>;
+	vdda-pll-supply = <&refgen>;
 	vdda18-supply = <&vreg_l7c>;
 	vdda33-supply = <&vreg_l9a>;
 	status = "okay";


### PR DESCRIPTION
Problem Statement:- Introduction of two PRs (1 and 2) leads to ADB going offline in few seconds for RB4.  Below are the logs which causes ADB to drop within few seconds of enumeration.
[   40.220063][   T49] refgen: disabling

On RB4, ADB is on micro-USB port (USB2). USB2 HS PHY needs three power supplies .8v, 1.8v and 3.3v. Below are existing values as per power grid of monaco.

vdda-pll-supply(.8v): l7a
vdda18-supply(1.8v): l7c
vdda33-supply(3.3v): l9a

But as per power grid analysis of monaco

vdda-pll-supply(.8v): l4a
vdda18-supply(1.8v): s4a
vdda33-supply(3.3v): l8a

The disparity in regulator causing ADB to drop offline within seconds of enumeration.

1) https://github.com/qualcomm-linux/kernel/commit/fc406be73a17d1c7507af464f177d4180f3909ac#diff-86029d2720afa1a45f36f218368644788a50c2d462cf81678ed00b7dcdef7d69R5766

2) https://github.com/qualcomm-linux/kernel/commit/2c9e4d7c6896ef285e884f0abf5c15d198cea469

Workaround solution:- Using refgen regulator for the 0.8 V rail (instead of the l7a) for USB2 HS PHY restores stable ADB connectivity. Presently this is taken as a workaround while we confirm the mismatch in the power grid understanding. 

CRs-Fixed: 4484198