### PR TITLE
arm64: dts: qcom: purwa: Correct the smmu-sid for Adreno X1-85 GPU

### DIFF
--- a/arch/arm64/boot/dts/qcom/purwa.dtsi
+++ b/arch/arm64/boot/dts/qcom/purwa.dtsi
@@ -55,6 +55,8 @@
 &gpu {
 	compatible = "qcom,adreno-43030c00", "qcom,adreno";
 
+	iommus = <&adreno_smmu 0 0x0>;
+
 	nvmem-cells = <&gpu_speed_bin>;
 	nvmem-cell-names = "speed_bin";
 


### PR DESCRIPTION
Correct the smmu-sid for Adreno X1-85 GPU.