### PR TITLE
PENDING: arm64: dts: qcom: sm8550: switch iris iommus to iommu-map

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8550.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8550.dtsi
@@ -18,6 +18,7 @@
 #include <dt-bindings/interconnect/qcom,icc.h>
 #include <dt-bindings/interconnect/qcom,sm8550-rpmh.h>
 #include <dt-bindings/mailbox/qcom-ipcc.h>
+#include <dt-bindings/media/qcom,sm8550-iris.h>
 #include <dt-bindings/power/qcom-rpmpd.h>
 #include <dt-bindings/power/qcom,rpmhpd.h>
 #include <dt-bindings/soc/qcom,gpr.h>
@@ -3292,8 +3293,8 @@
 			resets = <&gcc GCC_VIDEO_AXI0_CLK_ARES>;
 			reset-names = "bus";
 
-			iommus = <&apps_smmu 0x1940 0>,
-				 <&apps_smmu 0x1947 0>;
+			iommu-map = <IRIS_NON_PIXEL_VCODEC &apps_smmu 0x1940 0x0 0x1>,
+				 <IRIS_PIXEL &apps_smmu 0x1947 0x0 0x1>;
 			dma-coherent;
 
 			/*

--- a/include/dt-bindings/media/qcom,sm8550-iris.h
+++ b/include/dt-bindings/media/qcom,sm8550-iris.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _DT_BINDINGS_MEDIA_QCOM_SM8550_IRIS_H_
+#define _DT_BINDINGS_MEDIA_QCOM_SM8550_IRIS_H_
+
+/* Function identifiers for iommu-map to attach for the context bank devices */
+#define IRIS_NON_PIXEL_VCODEC		0
+#define IRIS_PIXEL			1
+
+#endif


### PR DESCRIPTION
Add a dt-bindings header include/dt-bindings/media/qcom,sm8550-iris.h defining IRIS_NON_PIXEL_VCODEC (0) and IRIS_PIXEL (1) function IDs.

Switch the iris video codec node in sm8550 (kailua) from the legacy 'iommus' property to 'iommu-map', using the above function IDs to identify the non-pixel and pixel context bank SMMU stream mappings.

Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-115
CRs-Fixed: 4496236