### PR TITLE
PENDING: arm64: dts: qcom: hamoa: switch iris iommus to iommu-map

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -16,6 +16,7 @@
 #include <dt-bindings/interconnect/qcom,x1e80100-rpmh.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <dt-bindings/mailbox/qcom-ipcc.h>
+#include <dt-bindings/media/qcom,sm8550-iris.h>
 #include <dt-bindings/phy/phy.h>
 #include <dt-bindings/phy/phy-qcom-qmp.h>
 #include <dt-bindings/power/qcom,rpmhpd.h>
@@ -5763,8 +5764,8 @@
 			resets = <&gcc GCC_VIDEO_AXI0_CLK_ARES>;
 			reset-names = "bus";
 
-			iommus = <&apps_smmu 0x1940 0>,
-				 <&apps_smmu 0x1947 0>;
+			iommu-map = <IRIS_NON_PIXEL_VCODEC &apps_smmu 0x1940 0x0 0x1>,
+				 <IRIS_PIXEL &apps_smmu 0x1947 0x0 0x1>;
 			dma-coherent;
 
 			/*


### PR DESCRIPTION
Switch the iris video codec node in hamoa from the legacy 'iommus' property to 'iommu-map', using IRIS_NON_PIXEL_VCODEC and IRIS_PIXEL function IDs to identify the non-pixel and pixel context bank SMMU stream mappings respectively.

Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-115
CRs-Fixed: 4496236
Depends-on: https://github.com/qualcomm-linux/kernel-topics/pull/918