### PR TITLE
arm64: dts: qcom: shikra: Add cpufreq scaling node

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -42,6 +42,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			qcom,freq-domain = <&cpufreq_hw 0>;
 		};
 
 		cpu1: cpu@100 {
@@ -52,6 +53,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			qcom,freq-domain = <&cpufreq_hw 0>;
 		};
 
 		cpu2: cpu@200 {
@@ -62,6 +64,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			qcom,freq-domain = <&cpufreq_hw 0>;
 		};
 
 		cpu3: cpu@300 {
@@ -72,6 +75,7 @@
 			next-level-cache = <&l2_3>;
 			capacity-dmips-mhz = <1946>;
 			dynamic-power-coefficient = <486>;
+			qcom,freq-domain = <&cpufreq_hw 1>;
 
 			l2_3: l2-cache {
 				compatible = "cache";
@@ -712,6 +716,24 @@
 
 				status = "disabled";
 			};
+		};
+
+		cpufreq_hw: cpufreq@fd91000 {
+			compatible = "qcom,shikra-cpufreq-rimps", "qcom,cpufreq-rimps";
+			reg = <0x0 0x0fd91000 0x0 0x1000>,
+			      <0x0 0x0fd92000 0x0 0x1000>;
+			reg-names = "freq-domain0",
+				    "freq-domain1";
+
+			clocks = <&rpmcc RPM_SMD_XO_CLK_SRC>, <&gcc GPLL0>;
+			clock-names = "xo", "alternate";
+
+			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "dcvsh-irq-0",
+					  "dcvsh-irq-1";
+
+			#freq-domain-cells = <1>;
 		};
 	};
 


### PR DESCRIPTION
Add cpufreq-hw node to support cpufreq scaling on Qualcomm Shikra SoCs.