### PR TITLE
arm64: dts: qcom: qcs6490-rb3gen2: fix root node overlay for phy-supply

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-staging.dtso
@@ -9,7 +9,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
-/ {
+&{/} {
 	qep_vreg: qep_vreg {
 		compatible = "regulator-fixed";
 		regulator-name = "qep_vreg";


### PR DESCRIPTION
The staging overlay used a bare "/ {" root node block to define the qep_vreg and aqr_vreg fixed regulators.  In a DT overlay, a bare "/ {" creates a new root fragment that is not merged into the base tree's root node; as a result the regulator nodes are never instantiated and the tc956x driver cannot resolve the phy-supply phandle, leading to a failed MDIO probe:

  tc956x_pci-eth 0001:05:00.1: No PHY found

Replace "/ {" with the overlay-correct "&{/} {" syntax so that the fragment is properly applied as an amendment to the base device-tree root node.  This ensures the regulator nodes are present at boot and the PHY powers up correctly.

CRs-Fixed: 4499524