### PR TITLE
arm64: dts: qcom: Fix assigned clock rate of usb master clock

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -781,7 +781,7 @@
 
 			assigned-clocks = <&gcc GCC_USB30_PRIM_MOCK_UTMI_CLK>,
 					  <&gcc GCC_USB30_PRIM_MASTER_CLK>;
-			assigned-clock-rates = <19200000>, <133333333>;
+			assigned-clock-rates = <19200000>, <200000000>;
 
 			interrupts-extended = <&intc GIC_SPI 255 IRQ_TYPE_LEVEL_HIGH>,
 					      <&intc GIC_SPI 302 IRQ_TYPE_LEVEL_HIGH>,


### PR DESCRIPTION
Set USB Prim master clock assigned rate to 200MHz.