### PR TITLE
QCLINUX: prune.config: Enable Realtek PHY config for Rb3Gen2 Industrial Board

### DIFF
--- a/arch/arm64/configs/prune.config
+++ b/arch/arm64/configs/prune.config
@@ -92,7 +92,6 @@
 # CONFIG_BROADCOM_PHY is not set
 # CONFIG_BCM54140_PHY is not set
 # CONFIG_MICROSEMI_PHY is not set
-# CONFIG_REALTEK_PHY is not set
 # CONFIG_ROCKCHIP_PHY is not set
 # CONFIG_DP83867_PHY is not set
 # CONFIG_DP83TD510_PHY is not set


### PR DESCRIPTION
The Rb3Gen2 Industrial Board has the Realtek RTL8221 PHY which fails to function correctly without the Realtek PHY driver. Remove CONFIG_REALTEK_PHY from prune.config to properly enable it.

CRs-Fixed: 4502917