### PR TITLE
arm64: dts: qcom: shikra: Add firmware-name to QUPv3 nodes

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
@@ -137,3 +137,8 @@
 		};
 	};
 };
+
+&qupv3_0 {
+	firmware-name = "qcom/shikra/qupv3fw.elf";
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
@@ -137,3 +137,8 @@
 		};
 	};
 };
+
+&qupv3_0 {
+	firmware-name = "qcom/shikra/qupv3fw.elf";
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-som.dtsi
@@ -126,3 +126,8 @@
 		};
 	};
 };
+
+&qupv3_0 {
+	firmware-name = "qcom/shikra/qupv3fw.elf";
+	status = "okay";
+};


### PR DESCRIPTION
Traditionally, firmware loading for Serial Engines (SE) in the QUP hardware of Qualcomm SoCs has been managed by TrustZone (TZ). While this approach ensures secure SE assignment and access control, it limits flexibility for developers who need to enable various protocols on different SEs.

Add the firmware-name property to QUPv3 nodes in the device tree to enable firmware loading from the Linux environment. Handle SE assignments and access control permissions directly within Linux, removing the dependency on TrustZone.