### PR TITLE
WORKAROUND: arm64: dts: qcom: monaco-evk: Use refgen regulator for us…

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
@@ -892,7 +892,7 @@
 };
 
 &usb_2_hsphy {
-	vdda-pll-supply = <&vreg_l7a>;
+	vdda-pll-supply = <&refgen>;
 	vdda18-supply = <&vreg_l7c>;
 	vdda33-supply = <&vreg_l9a>;
 


### PR DESCRIPTION
…b2 HS PHY

Problem Statement:- After the Introduction of commits (1 and 2) ADB goes offline a few seconds after USB enumeration on the micro‑USB (USB2) port.

The failure is consistently observed shortly after enumeration, with the following log indicating regulator shutdown:

[ 40.220063][ T49] refgen: disabling

On RB4, ADB operates over the USB2 HSPHY, which requires three power rails:

0.8 V (vdda‑pll)
1.8 V (vdda18)
3.3 V (vdda33)

Based on the current DTS configuration, the USB2 HS PHY regulators are as follows as per monaco power grid:

vdda-pll-supply (0.8 V): l7a
vdda18-supply (1.8 V): l7c
vdda33-supply (3.3 V): l9a

However, according to the Monaco power grid analysis, the regulators for the USB2 HS PHY should be:

vdda-pll-supply (0.8 V): l4a
vdda18-supply (1.8 V): s4a
vdda33-supply (3.3 V): l8a

This mismatch in regulator assignment results in unstable PHY power, causing ADB to drop offline shortly after USB enumeration.

Workaround solution:- As an interim workaround, the refgen regulator is used for the 0.8 V (vdda‑pll) rail instead of l7a. This change restores stable USB2 HS PHY operation and prevents ADB from disconnecting. Presently this is taken as a workaround while we confirm the mismatch in the power grid understanding.

1) fc406be (add Display Serial Interface device nodes)
2) 2c9e4d7 (add refgen regulator)

CRs-Fixed: 4484198