### PR TITLE
Revert "PENDING: media: iris: update MDT PAS load call for new API"

### DIFF
--- a/drivers/media/platform/qcom/iris/iris_firmware.c
+++ b/drivers/media/platform/qcom/iris/iris_firmware.c
@@ -30,6 +30,7 @@ static int iris_load_fw_to_memory(struct iris_core *core, const char *fw_name)
 	phys_addr_t mem_phys;
 	size_t res_size;
 	ssize_t fw_size;
+	void *mem_virt;
 	int ret;
 
 	if (strlen(fw_name) >= MAX_FIRMWARE_NAME_SIZE - 4)
@@ -60,16 +61,22 @@ static int iris_load_fw_to_memory(struct iris_core *core, const char *fw_name)
 		goto err_release_fw;
 	}
 
-	ret = qcom_mdt_pas_load(ctx, firmware, fw_name, NULL);
+	mem_virt = memremap(mem_phys, res_size, MEMREMAP_WC);
+	if (!mem_virt) {
+		ret = -ENOMEM;
+		goto err_release_fw;
+	}
+
+	ret = qcom_mdt_pas_load(ctx, firmware, fw_name, mem_virt, NULL);
 	qcom_scm_pas_metadata_release(ctx);
 	if (ret)
-		goto err_release_fw;
+		goto err_mem_unmap;
 
 	if (core->fw.iommu_domain) {
 		ret = iommu_map(core->fw.iommu_domain, 0, mem_phys, res_size,
 				IOMMU_READ | IOMMU_WRITE | IOMMU_PRIV, GFP_KERNEL);
 		if (ret)
-			goto err_release_fw;
+			goto err_mem_unmap;
 	}
 
 	ret = qcom_scm_pas_prepare_and_auth_reset(ctx);
@@ -82,6 +89,8 @@ static int iris_load_fw_to_memory(struct iris_core *core, const char *fw_name)
 
 err_iommu_unmap:
 	iommu_unmap(core->fw.iommu_domain, 0, res_size);
+err_mem_unmap:
+	memunmap(mem_virt);
 err_release_fw:
 	release_firmware(firmware);
 


### PR DESCRIPTION
This reverts commit e50a622d72418667d0747d59a772232054f85671.
This is needed to resolve the compilation failure
[M]  drivers/media/platform/qcom/venus/hfi_msgs.o
kernel/drivers/media/platform/qcom/iris/iris_firmware.c: In function ‘iris_load_fw_to_memory’:
kernel/drivers/media/platform/qcom/iris/iris_firmware.c:63:15: error: too few arguments to function ‘qcom_mdt_pas_load’
   63 |         ret = qcom_mdt_pas_load(ctx, firmware, fw_name, NULL);
      |               ^~~~~~~~~~~~~~~~~
In file included from kernel/drivers/media/platform/qcom/iris/iris_firmware.c:15:
kernel/include/linux/soc/qcom/mdt_loader.h:23:5: note: declared here
   23 | int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
      |     ^~~~~~~~~~~~~~~~~