### PR TITLE
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable 4-lane DisplayPor…

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -767,7 +767,7 @@
 };
 
 &mdss_dp_out {
-	data-lanes = <0 1>;
+	data-lanes = <0 1 2 3>;
 	remote-endpoint = <&usb_dp_qmpphy_dp_in>;
 };
 
@@ -1323,6 +1323,7 @@
 	vdda-phy-supply = <&vreg_l6b_1p2>;
 	vdda-pll-supply = <&vreg_l1b_0p912>;
 
+	mode-switch;
 	orientation-switch;
 
 	status = "okay";


### PR DESCRIPTION
…t Alt Mode

Add the mode-switch property to the QMP combo PHY so that mode-switch events are routed to it, allowing the PHY to enter DisplayPort Alternate Mode. Expand the DP data-lanes assignment from two to four lanes to make use of the full link bandwidth available in this configuration.

Link: https://lore.kernel.org/r/20260420-kodiak_4k-v1-1-83dfc66b8f06@oss.qualcomm.com