### PR TITLE
WORKAROUND: arm64: dts: qcom: monaco-evk: Enable Bluetooth support

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
@@ -16,6 +16,7 @@
 		ethernet0 = &ethernet0;
 		i2c1 = &i2c1;
 		serial0 = &uart7;
+		serial1 = &uart2;
 		serial2 = &uart6;
 	};
 
@@ -166,6 +167,29 @@
 
 		pinctrl-0 = <&cam2_avdd_2v8_en_default>;
 		pinctrl-names = "default";
+	};
+
+	vreg_dcin_12v: regulator-dcin-12v {
+		compatible = "regulator-fixed";
+
+		regulator-name = "VREG_DCIN_12V";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vreg_wcn_3p3: regulator-wcn-3p3 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "VREG_WCN_3P3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		vin-supply = <&vreg_dcin_12v>;
+
+		regulator-boot-on;
 	};
 };
 
@@ -834,6 +858,24 @@
 		pins = "gpio96";
 		function = "gpio";
 		bias-pull-up;
+	};
+};
+
+&uart2 {
+	status = "okay";
+
+	bluetooth: bluetooth {
+		compatible = "qcom,wcn6855-bt";
+		max-speed = <3200000>;
+
+		vddrfacmn-supply = <&vreg_wcn_3p3>;
+		vddaon-supply = <&vreg_wcn_3p3>;
+		vddwlcx-supply = <&vreg_wcn_3p3>;
+		vddwlmx-supply = <&vreg_wcn_3p3>;
+		vddbtcmx-supply = <&vreg_wcn_3p3>;
+		vddrfa0p8-supply = <&vreg_wcn_3p3>;
+		vddrfa1p2-supply = <&vreg_wcn_3p3>;
+		vddrfa1p8-supply = <&vreg_wcn_3p3>;
 	};
 };
 


### PR DESCRIPTION
There's a WCN6855 WiFi/Bluetooth module on an M.2 card. To make Bluetooth work, define the necessary device tree nodes, including UART configuration and power supplies.

The module provides a 3.3V supply originating from the main board's 12V rail. Add a fixed 12V regulator node as the DC-IN source and link it to the 3.3V regulator node to represent this power hierarchy.

Workaround: With the WCN6855 PMU node present, the driver unintentionally takes the pwrseq code path, which causes Bluetooth to fail to power up during an on -> off -> on transition. To unblock functionality, the PMU node is omitted and all Bluetooth power supply references point directly to vreg_wcn_3p3, keeping the driver on the non-pwrseq path.

This is a temporary workaround. Once a proper M.2 binding/solution is upstreamed, both DTS and driver changes will be re-submitted aligned with the M.2 model.

CRs-Fixed: 4513452