### PR TITLE
FROMLIST: arm64: dts: qcom: monaco: fix wrong connection for the replicator

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -2941,14 +2941,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				port@0 {
-					reg = <0>;
-
-					swao_rep_out0: endpoint {
-						remote-endpoint = <&qdss_rep_in>;
-					};
-				};
-
 				port@1 {
 					reg = <1>;
 
@@ -3657,6 +3649,14 @@
 			out-ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+
+					swao_rep_out0: endpoint {
+						remote-endpoint = <&qdss_rep_in>;
+					};
+				};
 
 				port@1 {
 					reg = <1>;


### PR DESCRIPTION
Fix the wrong connection for the qdss replicator device.

Link: https://lore.kernel.org/all/20260427-fix-monaco-coresight-dt-v1-1-1707017f20c5@oss.qualcomm.com/
Fixes: 0f43254763b3 ("arm64: dts: qcom: qcs8300: Add coresight nodes")