### PR TITLE
arm64: dts: qcom: Correct the TLMM base register address for shikra

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -423,7 +423,7 @@
 
 		tlmm: pinctrl@500000 {
 			compatible = "qcom,shikra-tlmm";
-			reg = <0x0 0x00500000 0x0 0x800000>;
+			reg = <0x0 0x00400000 0x0 0x800000>;
 
 			interrupts = <GIC_SPI 227 IRQ_TYPE_LEVEL_HIGH>;
 


### PR DESCRIPTION
Correct the TLMM base register address to allow proper programming and functioning of GPIOs for shikra.