### PR TITLE
FROMLIST: Add TRNG support for Glymur SoC

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -4051,6 +4051,11 @@
 			status = "disabled";
 		};
 
+		rng: rng@10c3000 {
+			compatible = "qcom,glymur-trng", "qcom,trng";
+			reg = <0x0 0x010c3000 0x0 0x1000>;
+		};
+
 		tcsr_mutex: hwlock@1f40000 {
 			compatible = "qcom,tcsr-mutex";
 			reg = <0x0 0x01f40000 0x0 0x20000>;


### PR DESCRIPTION
Glymur has a True Random Number Generator, add the node with the correct
compatible set.

Signed-off-by: Harshal Dev <harshal.dev@oss.qualcomm.com>