### PR TITLE
QCLINUX: arm64: dts: qcom: Add kodiak lite camx overlay dts

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -478,6 +478,10 @@ dtb-$(CONFIG_ARCH_QCOM)	+= monaco-evk-staging.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= monaco-staging.dtbo
 
+qcs5430-fps-camx-dtbs   := qcs6490-rb3gen2.dtb qcs5430-fps-camx.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM) += qcs5430-fps-camx.dtb
+
 qcs615-ride-camx-dtbs	:= qcs615-ride.dtb qcs615-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride-camx.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -482,6 +482,10 @@ qcs615-ride-camx-dtbs	:= qcs615-ride.dtb qcs615-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride-camx.dtb
 
+qcs5430-fps-camx-dtbs := qcs6490-rb3gen2.dtb qcs5430-fps-camx.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM) += qcs5430-fps-camx.dtb
+
 qcs6490-rb3gen2-vision-mezzanine-camx-dtbs := qcs6490-rb3gen2-vision-mezzanine.dtb \
 						      qcs6490-rb3gen2-vision-mezzanine-camx.dtbo
 

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -486,10 +486,6 @@ qcs615-ride-camx-dtbs	:= qcs615-ride.dtb qcs615-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride-camx.dtb
 
-qcs5430-fps-camx-dtbs := qcs6490-rb3gen2.dtb qcs5430-fps-camx.dtbo
-
-dtb-$(CONFIG_ARCH_QCOM) += qcs5430-fps-camx.dtb
-
 qcs6490-rb3gen2-vision-mezzanine-camx-dtbs := qcs6490-rb3gen2-vision-mezzanine.dtb \
 						      qcs6490-rb3gen2-vision-mezzanine-camx.dtbo
 

--- a/arch/arm64/boot/dts/qcom/qcs5430-fps-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs5430-fps-camx.dtso
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*/
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/qcom,gcc-sc7280.h>
+#include <dt-bindings/clock/qcom,camcc-sc7280.h>
+#include <dt-bindings/interconnect/qcom,sc7280.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/power/qcom-rpmpd.h>
+
+#include "qcs6490-camera.dtsi"
+#include "qcs6490-rb3gen2-camera-sensor.dtsi"
+
+&cam_csid2 {
+    status = "disabled";
+};
+
+&cam_vfe2 {
+    status = "disabled";
+};
+
+&camss {
+    status = "disabled";
+};
+
+&cci1 {
+    status = "disabled";
+};


### PR DESCRIPTION
Add CAMX overlay dts file for kodiak lite boards.

This change also enables the compilation of the CAMX overlay for kodiak lite boards.