### PR TITLE
Removed the glymur-iris.h dt-binding

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -16,7 +16,6 @@
 #include <dt-bindings/interconnect/qcom,glymur-rpmh.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <dt-bindings/mailbox/qcom-ipcc.h>
-#include <dt-bindings/media/qcom,glymur-iris.h>
 #include <dt-bindings/phy/phy-qcom-qmp.h>
 #include <dt-bindings/power/qcom,rpmhpd.h>
 #include <dt-bindings/power/qcom-rpmpd.h>


### PR DESCRIPTION
Removed the glymur-iris.h dt-bindings dependency.
There is a diff between https://lore.kernel.org/all/20260428-glymur-v3-12-8f28930f47d3@oss.qualcomm.com/ vs https://github.com/qualcomm-linux/kernel-topics/pull/1041/changes/8021339e22b56e1e65dba95e4ab029120a4f901d