### PR TITLE
WORKAROUND: power: reset: reboot-mode: fix NULL deref when dev is not…

### DIFF
--- a/drivers/firmware/psci/psci.c
+++ b/drivers/firmware/psci/psci.c
@@ -616,6 +616,7 @@ static int __init psci_init_vendor_reset(void)
 	}
 
 	reboot->write = psci_set_vendor_sys_reset2;
+	reboot->name = "psci";
 
 	ret = reboot_mode_register(reboot, of_fwnode_handle(np));
 	if (ret)

--- a/drivers/power/reset/reboot-mode.c
+++ b/drivers/power/reset/reboot-mode.c
@@ -120,7 +120,15 @@ static int reboot_mode_create_device(struct reboot_mode_driver *reboot)
 	struct reboot_mode_sysfs_data *priv;
 	struct mode_info *sysfs_info;
 	struct mode_info *info;
+	const char *dev_name;
 	int ret;
+
+	dev_name = reboot->name;
+	if (!dev_name) {
+		if (!reboot->dev || !reboot->dev->driver)
+			return -EINVAL;
+		dev_name = reboot->dev->driver->name;
+	}
 
 	priv = kzalloc_obj(*priv, GFP_KERNEL);
 	if (!priv)
@@ -147,7 +155,7 @@ static int reboot_mode_create_device(struct reboot_mode_driver *reboot)
 
 	priv->reboot_mode_device = device_create(&reboot_mode_class, NULL, 0,
 						 (void *)priv, "%s",
-						 reboot->dev->driver->name);
+						 dev_name);
 	if (IS_ERR(priv->reboot_mode_device)) {
 		ret = PTR_ERR(priv->reboot_mode_device);
 		goto error;
@@ -253,8 +261,16 @@ static inline void reboot_mode_unregister_device(struct reboot_mode_driver *rebo
 {
 	struct reboot_mode_sysfs_data *priv;
 	struct device *reboot_mode_device;
+	const char *dev_name;
 
-	reboot_mode_device = class_find_device(&reboot_mode_class, NULL, reboot->dev->driver->name,
+	dev_name = reboot->name;
+	if (!dev_name) {
+		if (!reboot->dev || !reboot->dev->driver)
+			return;
+		dev_name = reboot->dev->driver->name;
+	}
+
+	reboot_mode_device = class_find_device(&reboot_mode_class, NULL, dev_name,
 					       reboot_mode_match_by_name);
 
 	if (!reboot_mode_device)

--- a/include/linux/reboot-mode.h
+++ b/include/linux/reboot-mode.h
@@ -7,6 +7,7 @@
 
 struct reboot_mode_driver {
 	struct device *dev;
+	const char *name;
 	struct list_head head;
 	int (*write)(struct reboot_mode_driver *reboot, u64 magic);
 	struct notifier_block reboot_notifier;


### PR DESCRIPTION
… set

reboot_mode_create_device() and reboot_mode_unregister_device() unconditionally dereference reboot->dev->driver->name to name the sysfs device.  psci_init_vendor_reset() allocates a reboot_mode_driver with kzalloc (so reboot->dev == NULL) and never sets reboot->dev, causing a NULL pointer dereference at boot:

  Unable to handle kernel NULL pointer dereference at virtual address 0000000000000068
  pc : reboot_mode_register+0x334/0x3b8
  psci_init_vendor_reset+0xdc/0x128
  Kernel panic - not syncing: Oops: Fatal exception

The offset 0x68 is the 'driver' pointer inside struct device on arm64, confirming that reboot->dev itself is NULL.

Fix this by adding a 'name' field to struct reboot_mode_driver. reboot_mode_create_device() and reboot_mode_unregister_device() now prefer reboot->name; they fall back to reboot->dev->driver->name only when reboot->name is NULL, and return -EINVAL / return early if neither source is available.  Set reboot->name = "psci" in psci_init_vendor_reset() so the sysfs device is correctly named.

Existing device-based callers (nvmem-reboot-mode, syscon-reboot-mode, qcom-pon) are unaffected: they set reboot->dev before calling devm_reboot_mode_register(), so the fallback path is taken as before.

Fixes: cfaf0a90789a ("power: reset: reboot-mode: Expose sysfs for registered reboot_modes")
Fixes: 614b17a3ce6e ("firmware: psci: Implement vendor-specific resets as reboot-mode")
Reported-by: LAVA job 91409 <https://lava-oss.qualcomm.com/scheduler/job/91409>