### PR TITLE
WORKAROUND: Revert "drm/msm/dpu: enable virtual planes by default"

### DIFF
--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_kms.c
+++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_kms.c
@@ -52,7 +52,7 @@
 #define DPU_DEBUGFS_DIR "msm_dpu"
 #define DPU_DEBUGFS_HWMASKNAME "hw_log_mask"
 
-bool dpu_use_virtual_planes = true;
+bool dpu_use_virtual_planes;
 module_param(dpu_use_virtual_planes, bool, 0);
 
 static int dpu_kms_hw_init(struct msm_kms *kms);


### PR DESCRIPTION
Bootup crash seen on kaanapali-mtp board.

[    8.114249][    C0] [drm:dpu_encoder_frame_done_timeout:2731] [dpu error]enc33 frame done timeout
[    8.116480][  T284] Unable to handle kernel paging request at virtual address ffff800080e5e000
[    8.116488][  T284] Mem abort info:
[    8.116492][  T284]   ESR = 0x0000000096000007
[    8.116497][  T284]   EC = 0x25: DABT (current EL), IL = 32 bits
[    8.116502][  T284]   SET = 0, FnV = 0
[    8.116507][  T284]   EA = 0, S1PTW = 0
[    8.116511][  T284]   FSC = 0x07: level 3 translation fault
[    8.116516][  T284] Data abort info:
[    8.116519][  T284]   ISV = 0, ISS = 0x00000007, ISS2 = 0x00000000
[    8.116524][  T284]   CM = 0, WnR = 0, TnD = 0, TagAccess = 0
[    8.116529][  T284]   GCS = 0, Overlay = 0, DirtyBit = 0, Xs = 0
[    8.116535][  T284] swapper pgtable: 4k pages, 48-bit VAs, pgdp=00000009bf36c000
[    8.116541][  T284] [ffff800080e5e000] pgd=0000000000000000, p4d=1000000880346403, pud=1000000880347403, pmd=1000000881e2d403, pte=0000000000000000
[    8.116567][  T284] Internal error: Oops: 0000000096000007 [#1]  SMP

Revert the change for now to unblock.

This reverts commit b0907ee59e24d3dad572b4ccc6db018b00ca14c8.