### PR TITLE
FROMLIST: arm64: dts: qcom: hamoa: Enable LLCC/DDR/DDR_QOS dvfs

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -553,6 +553,10 @@
 				reg = <0x13>;
 				#power-domain-cells = <1>;
 			};
+
+			scmi_vendor: protocol@80 {
+				reg = <0x80>;
+			};
 		};
 	};
 


### PR DESCRIPTION
On Qualcomm Hamoa SoCs, the memlat governor and the mechanism to control the LLCC and DDR/DDR_QOS is hosted on the CPU Control Processor (CPUCP). Add the vendor protocol node to the existing SCMI transport to enable QCOM SCMI Generic Extension protocol on Hamoa SoCs.

Link: https://lore.kernel.org/lkml/20260507062237.78051-9-sibi.sankar@oss.qualcomm.com/