### PR TITLE
arm64: dts: qcom: Modify compatible for Shikra APCS device

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -1432,7 +1432,7 @@
 		};
 
 		apcs_glb: mailbox@f400000 {
-			compatible = "qcom,shikra-apcs-hmss-global";
+			compatible = "qcom,shikra-apss-shared", "qcom,sdm845-apss-shared";
 			reg = <0x0 0x0f400000 0x0 0x1000>;
 			#mbox-cells = <1>;
 		};


### PR DESCRIPTION
Modify compatible for Shikra mailbox APCS device and add fallback compatible string.