### PR TITLE
dt-bindings: clock: qcom: shikra-gcc: Add power-domains property

### DIFF
--- a/Documentation/devicetree/bindings/clock/qcom,shikra-gcc.yaml
+++ b/Documentation/devicetree/bindings/clock/qcom,shikra-gcc.yaml
@@ -4,15 +4,15 @@
 $id: http://devicetree.org/schemas/clock/qcom,shikra-gcc.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
-title: Qualcomm Global Clock & Reset Controller on Shikra
+title: Global Clock & Reset Controller on Qualcomm Shikra SoC
 
 maintainers:
   - Imran Shaik <imran.shaik@oss.qualcomm.com>
   - Taniya Das <taniya.das@oss.qualcomm.com>
 
 description: |
-  Qualcomm global clock control module provides the clocks, resets and power
-  domains on Shikra.
+  Global clock control module provides the clocks, resets and power
+  domains on Qualcomm Shikra SoC platform.
 
   See also: include/dt-bindings/clock/qcom,shikra-gcc.h
 
@@ -31,9 +31,14 @@ properties:
       - description: PCIE Pipe clock source
       - description: USB3 phy wrapper pipe clock source
 
+  power-domains:
+    items:
+      - description: CX domain
+
 required:
   - compatible
   - clocks
+  - power-domains
   - '#power-domain-cells'
 
 allOf:
@@ -44,20 +49,22 @@ unevaluatedProperties: false
 examples:
   - |
     #include <dt-bindings/clock/qcom,rpmcc.h>
+    #include <dt-bindings/power/qcom-rpmpd.h>
     clock-controller@1400000 {
         compatible = "qcom,shikra-gcc";
         reg = <0x01400000 0x1f0000>;
         clocks = <&rpmcc RPM_SMD_XO_CLK_SRC>,
-               <&sleep_clk>,
-               <&emac0_sgmiiphy_rclk>,
-               <&emac0_sgmiiphy_tclk>,
-               <&emac1_sgmiiphy_rclk>,
-               <&emac1_sgmiiphy_tclk>,
-               <&pcie_pipe_clk>,
-               <&usb3_phy_wrapper_gcc_usb30_pipe_clk>;
-      #clock-cells = <1>;
-      #reset-cells = <1>;
-      #power-domain-cells = <1>;
+                 <&sleep_clk>,
+                 <&emac0_sgmiiphy_rclk>,
+                 <&emac0_sgmiiphy_tclk>,
+                 <&emac1_sgmiiphy_rclk>,
+                 <&emac1_sgmiiphy_tclk>,
+                 <&pcie_pipe_clk>,
+                 <&usb3_phy_wrapper_gcc_usb30_pipe_clk>;
+        power-domains = <&rpmpd RPMPD_VDDCX>;
+        #clock-cells = <1>;
+        #power-domain-cells = <1>;
+        #reset-cells = <1>;
     };
 
 ...


### PR DESCRIPTION
Document the power-domains property in order to propagate the votes on GDSC to CX raill.

These chagnes are taken care in V2 series posted:
https://lore.kernel.org/linux-clk/20260508-shikra-gcc-rpmcc-clks-v2-0-83238ba24060@oss.qualcomm.com/T/#t