### PR TITLE
arm64: dts: qcom: shikra: Add CX power domain to GCC

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -823,6 +823,7 @@
 				 <0>,
 				 <0>,
 				 <0>;
+			power-domains = <&rpmpd RPMPD_VDDCX>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;
 			#power-domain-cells = <1>;


### PR DESCRIPTION
Add CX power domain support to GCC node on Shikra platform.