### PR TITLE
FROMLIST: pinctrl: qcom: Unconditionally mark gpio as wakeup enable

### DIFF
--- a/Documentation/devicetree/bindings/mailbox/qcom,apcs-kpss-global.yaml
+++ b/Documentation/devicetree/bindings/mailbox/qcom,apcs-kpss-global.yaml
@@ -49,6 +49,7 @@ properties:
               - qcom,qcs615-apss-shared
               - qcom,sc7180-apss-shared
               - qcom,sc8180x-apss-shared
+              - qcom,shikra-apss-shared
               - qcom,sm7150-apss-shared
               - qcom,sm8150-apss-shared
           - const: qcom,sdm845-apss-shared
@@ -65,7 +66,6 @@ properties:
           - qcom,msm8996-apcs-hmss-global
           - qcom,qcm2290-apcs-hmss-global
           - qcom,sdm845-apss-shared
-          - qcom,shikra-apcs-hmss-global
 
   reg:
     maxItems: 1
@@ -239,7 +239,6 @@ allOf:
               - qcom,msm8996-apcs-hmss-global
               - qcom,qcm2290-apcs-hmss-global
               - qcom,sdm845-apss-shared
-              - qcom,shikra-apcs-hmss-global
     then:
       properties:
         clocks: false


### PR DESCRIPTION
Mention compatible for the Qualcomm Shikra APCS block in the same block as sdm845-apss-shared since they share the same data.