### PR TITLE
arm64: dts: qcom: Update Min and max Voltages for Shikra Retail

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
@@ -176,43 +176,23 @@
 	regulators {
 		compatible = "qcom,rpm-pm2250-regulators";
 
-		pm4125_s1: s1 {
-			regulator-min-microvolt = <1396000>;
-			regulator-max-microvolt = <1950000>;
-		};
-
 		pm4125_s2: s2 {
 			regulator-min-microvolt = <1000000>;
 			regulator-max-microvolt = <1200000>;
 		};
 
-		pm4125_s4: s4 {
-			regulator-min-microvolt = <640000>;
-			regulator-max-microvolt = <1414000>;
-		};
-
-		pm4125_l1: l1 {
-			regulator-min-microvolt = <312000>;
-			regulator-max-microvolt = <1304000>;
-		};
-
-		pm4125_l2: l2 {
-			regulator-min-microvolt = <1000000>;
-			regulator-max-microvolt = <1200000>;
-		};
-
 		pm4125_l3: l3 {
-			regulator-min-microvolt = <570000>;
+			regulator-min-microvolt = <624000>;
 			regulator-max-microvolt = <650000>;
 		};
 
 		pm4125_l4: l4 {
-			regulator-min-microvolt = <1650000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l5: l5 {
-			regulator-min-microvolt = <1100000>;
+			regulator-min-microvolt = <1232000>;
 			regulator-max-microvolt = <1304000>;
 		};
 
@@ -227,7 +207,7 @@
 		};
 
 		pm4125_l8: l8 {
-			regulator-min-microvolt = <875000>;
+			regulator-min-microvolt = <928000>;
 			regulator-max-microvolt = <1000000>;
 		};
 
@@ -237,68 +217,63 @@
 		};
 
 		pm4125_l10: l10 {
-			regulator-min-microvolt = <1150000>;
+			regulator-min-microvolt = <1304000>;
 			regulator-max-microvolt = <1304000>;
 		};
 
-		pm4125_l11: l11 {
-			regulator-min-microvolt = <970000>;
-			regulator-max-microvolt = <1150000>;
-		};
-
 		pm4125_l12: l12 {
-			regulator-min-microvolt = <875000>;
+			regulator-min-microvolt = <928000>;
 			regulator-max-microvolt = <975000>;
 		};
 
 		pm4125_l13: l13 {
 			regulator-min-microvolt = <1800000>;
-			regulator-max-microvolt = <1950000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l14: l14 {
-			regulator-min-microvolt = <1700000>;
-			regulator-max-microvolt = <1950000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l15: l15 {
 			regulator-min-microvolt = <1800000>;
-			regulator-max-microvolt = <2000000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l16: l16 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <2000000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l17: l17 {
-			regulator-min-microvolt = <2900000>;
+			regulator-min-microvolt = <3000000>;
 			regulator-max-microvolt = <3544000>;
 		};
 
 		pm4125_l18: l18 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l19: l19 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l20: l20 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3544000>;
+			regulator-min-microvolt = <2952000>;
+			regulator-max-microvolt = <2952000>;
 		};
 
 		pm4125_l21: l21 {
-			regulator-min-microvolt = <2700000>;
-			regulator-max-microvolt = <3544000>;
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3056000>;
 		};
 
 		pm4125_l22: l22 {
-			regulator-min-microvolt = <3200000>;
-			regulator-max-microvolt = <3400000>;
+			regulator-min-microvolt = <3304000>;
+			regulator-max-microvolt = <3304000>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
@@ -177,43 +177,23 @@
 	regulators {
 		compatible = "qcom,rpm-pm2250-regulators";
 
-		pm4125_s1: s1 {
-			regulator-min-microvolt = <1396000>;
-			regulator-max-microvolt = <1950000>;
-		};
-
 		pm4125_s2: s2 {
 			regulator-min-microvolt = <1000000>;
 			regulator-max-microvolt = <1200000>;
 		};
 
-		pm4125_s4: s4 {
-			regulator-min-microvolt = <640000>;
-			regulator-max-microvolt = <1414000>;
-		};
-
-		pm4125_l1: l1 {
-			regulator-min-microvolt = <312000>;
-			regulator-max-microvolt = <1304000>;
-		};
-
-		pm4125_l2: l2 {
-			regulator-min-microvolt = <1000000>;
-			regulator-max-microvolt = <1200000>;
-		};
-
 		pm4125_l3: l3 {
-			regulator-min-microvolt = <570000>;
+			regulator-min-microvolt = <624000>;
 			regulator-max-microvolt = <650000>;
 		};
 
 		pm4125_l4: l4 {
-			regulator-min-microvolt = <1650000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l5: l5 {
-			regulator-min-microvolt = <1100000>;
+			regulator-min-microvolt = <1232000>;
 			regulator-max-microvolt = <1304000>;
 		};
 
@@ -228,7 +208,7 @@
 		};
 
 		pm4125_l8: l8 {
-			regulator-min-microvolt = <875000>;
+			regulator-min-microvolt = <928000>;
 			regulator-max-microvolt = <1000000>;
 		};
 
@@ -238,68 +218,63 @@
 		};
 
 		pm4125_l10: l10 {
-			regulator-min-microvolt = <1150000>;
+			regulator-min-microvolt = <1304000>;
 			regulator-max-microvolt = <1304000>;
 		};
 
-		pm4125_l11: l11 {
-			regulator-min-microvolt = <970000>;
-			regulator-max-microvolt = <1150000>;
-		};
-
 		pm4125_l12: l12 {
-			regulator-min-microvolt = <875000>;
+			regulator-min-microvolt = <928000>;
 			regulator-max-microvolt = <975000>;
 		};
 
 		pm4125_l13: l13 {
 			regulator-min-microvolt = <1800000>;
-			regulator-max-microvolt = <1950000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l14: l14 {
-			regulator-min-microvolt = <1700000>;
-			regulator-max-microvolt = <1950000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l15: l15 {
 			regulator-min-microvolt = <1800000>;
-			regulator-max-microvolt = <2000000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l16: l16 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <2000000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
 		};
 
 		pm4125_l17: l17 {
-			regulator-min-microvolt = <2900000>;
+			regulator-min-microvolt = <3000000>;
 			regulator-max-microvolt = <3544000>;
 		};
 
 		pm4125_l18: l18 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l19: l19 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3300000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 		};
 
 		pm4125_l20: l20 {
-			regulator-min-microvolt = <1504000>;
-			regulator-max-microvolt = <3544000>;
+			regulator-min-microvolt = <2952000>;
+			regulator-max-microvolt = <2952000>;
 		};
 
 		pm4125_l21: l21 {
-			regulator-min-microvolt = <2700000>;
-			regulator-max-microvolt = <3544000>;
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3056000>;
 		};
 
 		pm4125_l22: l22 {
-			regulator-min-microvolt = <3200000>;
-			regulator-max-microvolt = <3400000>;
+			regulator-min-microvolt = <3304000>;
+			regulator-max-microvolt = <3304000>;
 		};
 	};
 };


### PR DESCRIPTION
Remove unused regulators (s1, s4, l1, l2, l11) and tighten min/max voltage ranges for remaining rails to match actual operating voltages derived from PGA report analysis.