### PR TITLE
misc: fastrpc: Introduce cache maintenance operations

### DIFF
--- a/drivers/misc/fastrpc.c
+++ b/drivers/misc/fastrpc.c
@@ -187,6 +187,7 @@ struct fastrpc_buf_overlap {
 	u64 mstart;
 	u64 mend;
 	u64 offset;
+	bool do_cmo;
 };
 
 struct fastrpc_buf {
@@ -255,6 +256,7 @@ struct fastrpc_session_ctx {
 	int sid;
 	bool used;
 	bool valid;
+	bool coherent;
 };
 
 struct fastrpc_soc_data {
@@ -329,6 +331,18 @@ static inline u64 fastrpc_sid_offset(struct fastrpc_channel_ctx *cctx,
 {
 	return (u64)sctx->sid << cctx->soc_data->sid_pos;
 }
+
+/*
+ * Align buffer size to kernel page granularity for dma-buf cache maintenance.
+ */
+static inline uint64_t buf_page_size(uint64_t size)
+{
+	int cache_align = dma_get_cache_alignment();
+	uint64_t sz = ALIGN(size, cache_align);
+
+	return max_t(uint64_t, sz, (uint64_t)cache_align);
+}
+
 
 static void fastrpc_free_map(struct kref *ref)
 {
@@ -558,7 +572,9 @@ static int olaps_cmp(const void *a, const void *b)
 static void fastrpc_get_buff_overlaps(struct fastrpc_invoke_ctx *ctx)
 {
 	u64 max_end = 0;
+	int max_raix = -1;
 	int i;
+	int inbufs = REMOTE_SCALARS_INBUFS(ctx->sc);
 
 	for (i = 0; i < ctx->nbufs; ++i) {
 		ctx->olaps[i].start = ctx->args[i].ptr;
@@ -578,6 +594,9 @@ static void fastrpc_get_buff_overlaps(struct fastrpc_invoke_ctx *ctx)
 			if (ctx->olaps[i].end > max_end) {
 				max_end = ctx->olaps[i].end;
 			} else {
+				if ((max_raix < inbufs && ctx->olaps[i].raix + 1 > inbufs) ||
+					(ctx->olaps[i].raix < inbufs && max_raix + 1 > inbufs))
+					ctx->olaps[i].do_cmo = true;
 				ctx->olaps[i].mend = 0;
 				ctx->olaps[i].mstart = 0;
 			}
@@ -587,6 +606,7 @@ static void fastrpc_get_buff_overlaps(struct fastrpc_invoke_ctx *ctx)
 			ctx->olaps[i].mstart = ctx->olaps[i].start;
 			ctx->olaps[i].offset = 0;
 			max_end = ctx->olaps[i].end;
+			max_raix = ctx->olaps[i].raix;
 		}
 	}
 }
@@ -806,7 +826,7 @@ static int fastrpc_map_attach(struct fastrpc_user *fl, int fd,
 		err = PTR_ERR(map->attach);
 		goto attach_err;
 	}
-
+	if (!sess->coherent)
 	table = dma_buf_map_attachment_unlocked(map->attach, DMA_BIDIRECTIONAL);
 	if (IS_ERR(table)) {
 		err = PTR_ERR(table);
@@ -973,6 +993,70 @@ static int fastrpc_create_maps(struct fastrpc_invoke_ctx *ctx)
 	return 0;
 }
 
+static int fastrpc_flush_args(struct fastrpc_invoke_ctx *ctx,
+	union fastrpc_remote_arg *rpra)
+{
+	int oix, inbufs, outbufs;
+	struct device *dev = ctx->fl->sctx->dev;
+
+	inbufs = REMOTE_SCALARS_INBUFS(ctx->sc);
+	outbufs = REMOTE_SCALARS_OUTBUFS(ctx->sc);
+	for (oix = 0; oix < inbufs+outbufs; ++oix) {
+		int i = ctx->olaps[oix].raix;
+		struct fastrpc_map *map = ctx->maps[i];
+
+		if (i+1 > inbufs)
+			continue;
+		if (!map)
+			continue;
+		if (rpra[i].buf.len && ctx->olaps[oix].mstart) {
+			if (map->buf) {
+				if ((buf_page_size(ctx->olaps[oix].mend -
+				ctx->olaps[oix].mstart)) == map->size ) {
+					dma_buf_begin_cpu_access(map->buf, DMA_TO_DEVICE);
+					dma_buf_end_cpu_access(map->buf, DMA_TO_DEVICE);
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+static int fastrpc_inv_args(struct fastrpc_invoke_ctx *ctx)
+{
+	int i, inbufs, outbufs;
+	uint32_t sc = ctx->sc;
+	union fastrpc_remote_arg *rpra = ctx->rpra;
+	struct device *dev = ctx->fl->sctx->dev;
+
+	inbufs = REMOTE_SCALARS_INBUFS(sc);
+	outbufs = REMOTE_SCALARS_OUTBUFS(sc);
+	for (i = 0; i < inbufs+outbufs; ++i) {
+		int over = ctx->olaps[i].raix;
+		struct fastrpc_map *map = ctx->maps[over];
+
+		if (over + 1 <= inbufs)
+			continue;
+		if (!rpra[over].buf.len)
+			continue;
+		if (!map)
+			continue;
+		if (((uintptr_t)rpra & PAGE_MASK) ==
+			((uintptr_t)rpra[over].buf.pv & PAGE_MASK))
+			continue;
+		if (ctx->olaps[i].mstart) {
+			if (map->buf) {
+				if (((buf_page_size(ctx->olaps[i].mend -
+					ctx->olaps[i].mstart)) == map->size)) {
+					dma_buf_begin_cpu_access(map->buf, DMA_FROM_DEVICE);
+					dma_buf_end_cpu_access(map->buf, DMA_TO_DEVICE);
+				}
+			}
+		}
+	}
+	return 0;
+}
+
 static struct fastrpc_invoke_buf *fastrpc_invoke_buf_start(union fastrpc_remote_arg *pra, int len)
 {
 	return (struct fastrpc_invoke_buf *)(&pra[len]);
@@ -1091,6 +1175,12 @@ static int fastrpc_get_args(u32 kernel, struct fastrpc_invoke_ctx *ctx)
 				memcpy(dst, src, len);
 			}
 		}
+	}
+
+	if (!ctx->fl->sctx->coherent) {
+		err =  fastrpc_flush_args(ctx, rpra);
+		if (err)
+			goto bail;
 	}
 
 	for (i = ctx->nbufs; i < ctx->nscalars; ++i) {
@@ -1220,6 +1310,11 @@ static int fastrpc_internal_invoke(struct fastrpc_user *fl,  u32 kernel,
 	if (err)
 		goto bail;
 
+	if (!fl->sctx->coherent) {
+		err = fastrpc_inv_args(ctx);
+		if (err)
+			goto bail;
+	}
 	/* make sure that all CPU memory writes are seen by DSP */
 	dma_wmb();
 	/* Send invoke buffer to remote dsp */
@@ -1239,6 +1334,11 @@ static int fastrpc_internal_invoke(struct fastrpc_user *fl,  u32 kernel,
 
 	/* make sure that all memory writes by DSP are seen by CPU */
 	dma_rmb();
+	if (!fl->sctx->coherent) {
+		err = fastrpc_inv_args(ctx);
+		if (err)
+			goto bail;
+	}
 	/* populate all the output buffers with results */
 	err = fastrpc_put_args(ctx, kernel);
 	if (err)
@@ -2217,6 +2317,7 @@ static int fastrpc_cb_probe(struct platform_device *pdev)
 	sess->used = false;
 	sess->valid = true;
 	sess->dev = dev;
+	sess->coherent = of_property_read_bool(dev->of_node, "dma-coherent");
 	dev_set_drvdata(dev, sess);
 
 	if (cctx->domain_id == CDSP_DOMAIN_ID)


### PR DESCRIPTION
Introduce cache maintenance operations for remote arguments
in fastrpc driver for non-dma coherent targets. 