### PR TITLE
Shikra dt bluetooth.

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -18,6 +18,7 @@
 		mmc0 = &sdhc_1;
 		mmc1 = &sdhc_2; /* SDC2 SD card slot */
 		serial0 = &uart0;
+		serial1 = &uart8;
 	};
 
 	chosen {
@@ -86,6 +87,17 @@
 
 &uart0 {
 	status = "okay";
+};
+
+&uart8 {
+	status = "okay";
+
+	bluetooth {
+		vddio-supply = <&pm4125_l7>;
+		vddxo-supply = <&pm4125_l13>;
+		vddrf-supply = <&pm4125_l10>;
+		vddch0-supply = <&pm4125_l22>;
+	};
 };
 
 &usb_1 {

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -18,6 +18,7 @@
 		mmc0 = &sdhc_1;
 		mmc1 = &sdhc_2; /* SDC2 SD card slot */
 		serial0 = &uart0;
+		serial1 = &uart8;
 	};
 
 	chosen {
@@ -80,6 +81,17 @@
 
 &uart0 {
 	status = "okay";
+};
+
+&uart8 {
+	status = "okay";
+
+	bluetooth {
+		vddio-supply = <&pm4125_l7>;
+		vddxo-supply = <&pm4125_l13>;
+		vddrf-supply = <&pm4125_l10>;
+		vddch0-supply = <&pm4125_l22>;
+	};
 };
 
 &usb_1 {

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -18,6 +18,7 @@
 		mmc0 = &sdhc_1;
 		mmc1 = &sdhc_2; /* SDC2 SD card slot */
 		serial0 = &uart0;
+		serial1 = &uart8;
 	};
 
 	chosen {
@@ -82,6 +83,17 @@
 
 &uart0 {
 	status = "okay";
+};
+
+&uart8 {
+	status = "okay";
+
+	bluetooth {
+		vddio-supply = <&pm8150_s4>;
+		vddxo-supply = <&pm8150_l12>;
+		vddrf-supply = <&pm8150_l8>;
+		vddch0-supply = <&vreg_wlan_3p3_dummy>;
+	};
 };
 
 &usb_1 {

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -2160,6 +2160,14 @@
 				pinctrl-names = "default";
 
 				status = "disabled";
+
+				bluetooth {
+					compatible = "qcom,wcn3988-bt";
+
+					enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+					max-speed = <3200000>;
+				};
+
 			};
 
 			i2c9: i2c@4aa4000 {


### PR DESCRIPTION
arm64: dts: qcom: shikra: Enable BT support on EVK boards.

Enable uart8 and add WCN3988 Bluetooth node with board-specific regulator supplies across CQM, CQS and IQS Shikra EVK variants.