### PR TITLE
PENDING: arm64: dts: qcom: talos: enable video codec on Talos

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/talos-el2.dtso
@@ -5,6 +5,8 @@
  * Talos specific modifications required to boot in EL2.
  */
 
+#include <dt-bindings/media/qcom,qcs615-venus.h>
+
 /dts-v1/;
 /plugin/;
 
@@ -21,5 +23,6 @@
 };
 
 &venus {
-	status = "disabled";
+	iommu-map = <VENUS_FIRMWARE &apps_smmu 0xe42 0x0 0x1>;
+	status = "okay";
 };


### PR DESCRIPTION
Enable video codec on Talos in the EL2 configuration and describe the firmware IOMMU mapping using the iommu-map property.

https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109
CRs-Fixed: 4534570