### PR TITLE
enable video codec on Talos

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/talos-el2.dtso
@@ -5,6 +5,8 @@
  * Talos specific modifications required to boot in EL2.
  */
 
+#include <dt-bindings/media/qcom,qcs615-venus.h>
+
 /dts-v1/;
 /plugin/;
 
@@ -21,5 +23,6 @@
 };
 
 &venus {
-	status = "disabled";
+	iommu-map = <VENUS_FIRMWARE &apps_smmu 0xe42 0x0 0x1>;
+	status = "okay";
 };


### PR DESCRIPTION
Enable video codec on Talos in the EL2 configuration and describe the firmware IOMMU mapping using the iommu-map property.

The logic for creating the firmware device in the Venus driver was originally implemented by referring to the Iris driver.
However, based on the latest feedback from the community, the Iris driver is expected to create devices by implementing a proper bus_type. Iris driver will update the patch. As a result, the Venus driver needs to be updated to align with the Iris driver accordingly.

For the DT part, due to the following changes, the iommu-map configuration can no longer use 4 cells. This introduces a new compatibility issue. Vijayanand is planning to address this, and once iommu-map supports the 4-cell format again, the DT changes will be updated and resubmitted to upstream.

00e90ec96c5f FROMLIST: of: Respect #{iommu,msi}-cells in maps
1e6e50385731 FROMLIST: of: Factor arguments passed to of_map_id() into a struct
d47bb88b0cf5 FROMLIST: of: Add convenience wrappers for of_map_id()

https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109
CRs-Fixed: 4534570