### PR TITLE
FROMLIST: PCI: qcom: Set max OPP before DBI access during resume

### DIFF
--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -1692,6 +1692,22 @@ static void qcom_pcie_icc_opp_update(struct qcom_pcie *pcie)
 	}
 }
 
+static int qcom_pcie_set_max_opp(struct device *dev)
+{
+	unsigned long max_freq = ULONG_MAX;
+	struct dev_pm_opp *opp;
+	int ret;
+
+	opp = dev_pm_opp_find_freq_floor(dev, &max_freq);
+	if (IS_ERR(opp))
+		return PTR_ERR(opp);
+
+	ret = dev_pm_opp_set_opp(dev, opp);
+	dev_pm_opp_put(opp);
+
+	return ret;
+}
+
 static int qcom_pcie_link_transition_count(struct seq_file *s, void *data)
 {
 	struct qcom_pcie *pcie = (struct qcom_pcie *)dev_get_drvdata(s->private);
@@ -1924,9 +1940,7 @@ static int qcom_pcie_probe(struct platform_device *pdev)
 	struct qcom_pcie_perst *perst, *tmp_perst;
 	struct qcom_pcie_port *port, *tmp_port;
 	const struct qcom_pcie_cfg *pcie_cfg;
-	unsigned long max_freq = ULONG_MAX;
 	struct device *dev = &pdev->dev;
-	struct dev_pm_opp *opp;
 	struct qcom_pcie *pcie;
 	struct dw_pcie_rp *pp;
 	struct resource *res;
@@ -2030,21 +2044,9 @@ static int qcom_pcie_probe(struct platform_device *pdev)
 	 * probe(), OPP will be updated using qcom_pcie_icc_opp_update().
 	 */
 	if (!ret) {
-		opp = dev_pm_opp_find_freq_floor(dev, &max_freq);
-		if (IS_ERR(opp)) {
-			ret = PTR_ERR(opp);
-			dev_err_probe(pci->dev, ret,
-				      "Unable to find max freq OPP\n");
-			goto err_pm_runtime_put;
-		} else {
-			ret = dev_pm_opp_set_opp(dev, opp);
-		}
-
-		dev_pm_opp_put(opp);
+		ret = qcom_pcie_set_max_opp(dev);
 		if (ret) {
-			dev_err_probe(pci->dev, ret,
-				      "Failed to set OPP for freq %lu\n",
-				      max_freq);
+			dev_err_probe(dev, ret, "Failed to set max OPP in probe\n");
 			goto err_pm_runtime_put;
 		}
 
@@ -2189,6 +2191,14 @@ static int qcom_pcie_resume_noirq(struct device *dev)
 			goto disable_icc_cpu;
 		}
 
+		if (pcie->use_pm_opp) {
+			ret = qcom_pcie_set_max_opp(dev);
+			if (ret) {
+				dev_err(dev, "Failed to set max OPP in resume: %d\n", ret);
+				return ret;
+			}
+		}
+
 		/*
 		 * Ignore -ENODEV & -EIO here since it is expected when no endpoint is
 		 * connected to the PCIe link.
@@ -2198,6 +2208,14 @@ static int qcom_pcie_resume_noirq(struct device *dev)
 			goto disable_icc_mem;
 	} else {
 		if (pm_suspend_target_state != PM_SUSPEND_MEM) {
+			if (pcie->use_pm_opp) {
+				ret = qcom_pcie_set_max_opp(dev);
+				if (ret) {
+					dev_err(dev, "Failed to set max OPP in resume: %d\n", ret);
+					return ret;
+				}
+			}
+
 			ret = icc_enable(pcie->icc_cpu);
 			if (ret) {
 				dev_err(dev, "Failed to enable CPU-PCIe interconnect path: %d\n",


### PR DESCRIPTION
Before accessing DBI registers during resume, the OPP (Operating Performance Point) must be set to maximum to ensure the required voltage corner is available. Without this, DBI access may fail on some platforms.

Refactor the open-coded max OPP selection in probe() into a helper qcom_pcie_set_max_opp(), and call it during resume before re-enabling the CPU-PCIe interconnect.

Link: https://lore.kernel.org/r/20260416-setmaxopp-v1-1-6a74e2d945a0@oss.qualcomm.com