### PR TITLE
arm64: dts: qcom: shikra: Add pm4125 s1 regulator

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
@@ -176,6 +176,11 @@
 	regulators {
 		compatible = "qcom,rpm-pm2250-regulators";
 
+		pm4125_s1: s1 {
+			regulator-min-microvolt = <1396000>;
+			regulator-max-microvolt = <1396000>;
+		};
+
 		pm4125_s2: s2 {
 			regulator-min-microvolt = <1000000>;
 			regulator-max-microvolt = <1200000>;

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
@@ -177,6 +177,11 @@
 	regulators {
 		compatible = "qcom,rpm-pm2250-regulators";
 
+		pm4125_s1: s1 {
+			regulator-min-microvolt = <1396000>;
+			regulator-max-microvolt = <1396000>;
+		};
+
 		pm4125_s2: s2 {
 			regulator-min-microvolt = <1000000>;
 			regulator-max-microvolt = <1200000>;


### PR DESCRIPTION
Add pm4125_s1 regulator node at fixed 1.396V to both shikra-cqm-som and shikra-cqs-som. This rail is used by the audio subsystem.