### PR TITLE
misc: fastrpc: fix NULL dereference on coherent sessions in fastrpc_m…

### DIFF
--- a/drivers/misc/fastrpc.c
+++ b/drivers/misc/fastrpc.c
@@ -826,7 +826,6 @@ static int fastrpc_map_attach(struct fastrpc_user *fl, int fd,
 		err = PTR_ERR(map->attach);
 		goto attach_err;
 	}
-	if (!sess->coherent)
 	table = dma_buf_map_attachment_unlocked(map->attach, DMA_BIDIRECTIONAL);
 	if (IS_ERR(table)) {
 		err = PTR_ERR(table);


### PR DESCRIPTION
Commit c7d8100749c6 introduced a brace-less if that skips the dma_buf_map_attachment_unlocked() call when sess->coherent is true, leaving 'table' uninitialized. The unconditional IS_ERR(table) check that follows does not catch NULL, so execution continues with a NULL sg_table, causing a level-0 translation fault when the sgl pointer is dereferenced. Remove the guard; the mapping is always needed to obtain DMA addresses consumed by the rest of the function.