### PR TITLE
soc: qcom: pd-mapper: Add shikra PD support for CQM/CQS/IQS

### DIFF
--- a/drivers/soc/qcom/qcom_pd_mapper.c
+++ b/drivers/soc/qcom/qcom_pd_mapper.c
@@ -456,6 +456,11 @@ static const struct qcom_pdm_domain_data *sc8280xp_domains[] = {
 	NULL,
 };
 
+static const struct qcom_pdm_domain_data *shikra_cqm_domains[] = {
+	&mpss_wlan_pd,
+	NULL,
+};
+
 /* Unlike SDM660, SDM630/636 lack CDSP */
 static const struct qcom_pdm_domain_data *sdm630_domains[] = {
 	&adsp_audio_pd,
@@ -599,6 +604,9 @@ static const struct of_device_id qcom_pdm_domains[] __maybe_unused = {
 	{ .compatible = "qcom,sc7280", .data = sc7280_domains, },
 	{ .compatible = "qcom,sc8180x", .data = sc8180x_domains, },
 	{ .compatible = "qcom,sc8280xp", .data = sc8280xp_domains, },
+	{ .compatible = "qcom,shikra-cqm", .data = shikra_cqm_domains, },
+	{ .compatible = "qcom,shikra-cqs", .data = shikra_cqm_domains, },
+	{ .compatible = "qcom,shikra-iqs", .data = shikra_cqm_domains, },
 	{ .compatible = "qcom,sdm630", .data = sdm630_domains, },
 	{ .compatible = "qcom,sdm636", .data = sdm630_domains, },
 	{ .compatible = "qcom,sda660", .data = sdm660_domains, },


### PR DESCRIPTION
soc: qcom: pd-mapper: Add shikra PD support for CQM/CQS/IQS
All Shikra SoC variants (CQM, CQS, IQS) share the same protection
domain requirements: mpss_wlan_pd only. audio_pd is not required on
any of these variants.

Introduce shikra_cqm_domains with mpss_wlan_pd and wire all three
compatibles (qcom,shikra-cqm, qcom,shikra-cqs, qcom,shikra-iqs) to
it.

Signed-off-by: Anurag Pateriya <apateriy@qti.qualcomm.com>