### PR TITLE
soc: qcom: rpmpd: Reuse sm6125 power domains for shikra

### DIFF
--- a/drivers/pmdomain/qcom/rpmpd.c
+++ b/drivers/pmdomain/qcom/rpmpd.c
@@ -863,21 +863,6 @@ static const struct rpmpd_desc sdm660_desc = {
 	.max_state = RPM_SMD_LEVEL_TURBO,
 };
 
-static struct rpmpd *shikra_rpmpds[] = {
-	[RPMPD_VDDCX] =		&cx_rwcx0_lvl,
-	[RPMPD_VDDCX_AO] =	&cx_rwcx0_lvl_ao,
-	[RPMPD_VDDCX_VFL] =	&cx_rwcx0_vfl,
-	[RPMPD_VDDMX] =		&mx_rwmx0_lvl,
-	[RPMPD_VDDMX_AO] =	&mx_rwmx0_lvl_ao,
-	[RPMPD_VDDMX_VFL] =	&mx_rwmx0_vfl,
-};
-
-static const struct rpmpd_desc shikra_desc = {
-	.rpmpds = shikra_rpmpds,
-	.num_pds = ARRAY_SIZE(shikra_rpmpds),
-	.max_state = RPM_SMD_LEVEL_TURBO_NO_CPR,
-};
-
 static struct rpmpd *sm6115_rpmpds[] = {
 	[SM6115_VDDCX] =	&cx_rwcx0_lvl,
 	[SM6115_VDDCX_AO] =	&cx_rwcx0_lvl_ao,
@@ -908,6 +893,12 @@ static const struct rpmpd_desc sm6125_desc = {
 	.rpmpds = sm6125_rpmpds,
 	.num_pds = ARRAY_SIZE(sm6125_rpmpds),
 	.max_state = RPM_SMD_LEVEL_BINNING,
+};
+
+static const struct rpmpd_desc shikra_desc = {
+	.rpmpds = sm6125_rpmpds,
+	.num_pds = ARRAY_SIZE(sm6125_rpmpds),
+	.max_state = RPM_SMD_LEVEL_TURBO_NO_CPR,
 };
 
 static struct rpmpd *sm6375_rpmpds[] = {


### PR DESCRIPTION
Shikra shares the same power domain topology as sm6125. Remove the dedicated shikra_rpmpds[] and update shikra_desc to reuse sm6125_rpmpds[] with RPM_SMD_LEVEL_TURBO_NO_CPR.