### PR TITLE
QCLINUX: arm64: dts: qcom: add hamoa CAMX EL2 overlay

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -479,6 +479,10 @@ hamoa-evk-camx-dtbs  := hamoa-iot-evk.dtb hamoa-evk-camx.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= hamoa-evk-camx.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= hamoa-evk-camx.dtbo
 
+hamoa-camx-el2-dtbs  := hamoa-iot-evk-el2.dtb hamoa-evk-camx.dtbo hamoa-camx-el2.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= hamoa-camx-el2.dtb
+
 lemans-evk-camx-dtbs	:= lemans-evk.dtb lemans-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= lemans-evk-camx.dtb

--- a/arch/arm64/boot/dts/qcom/hamoa-camx-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/hamoa-camx-el2.dtso
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/soc@0/qcom,cam-icp";
+		__overlay__ {
+			camera-firmware {
+				iommus = <&apps_smmu 0x1901 0x0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add a device tree overlay to enable EL2 boot support for the
Hamoa platform with CAMX configuration.

CRs-Fixed: 4538425
