### PR TITLE
WORKAROUND: misc: fastrpc: flush IOMMU TLB after releasing DSP process

### DIFF
--- a/drivers/misc/fastrpc.c
+++ b/drivers/misc/fastrpc.c
@@ -23,6 +23,7 @@
 #include <uapi/misc/fastrpc.h>
 #include <linux/of_reserved_mem.h>
 #include <linux/bits.h>
+#include <linux/iommu.h>
 
 #define ADSP_DOMAIN_ID (0)
 #define MDSP_DOMAIN_ID (1)
@@ -1585,6 +1586,13 @@ static int fastrpc_device_release(struct inode *inode, struct file *file)
 	unsigned long flags;
 
 	fastrpc_release_current_dsp_process(fl);
+	if (fl->sctx && fl->sctx->dev) {
+		struct iommu_domain *domain =
+			iommu_get_domain_for_dev(fl->sctx->dev);
+
+		if (domain)
+			iommu_flush_iotlb_all(domain);
+	}
 
 	spin_lock_irqsave(&cctx->lock, flags);
 	list_del(&fl->user);


### PR DESCRIPTION
When a FastRPC session is closed, an INIT_RELEASE is sent to the DSP which begins an asynchronous ASID teardown. If a new INIT_CREATE arrives before teardown completes, the DSP returns AEE_EQURTBADASID (0x8000054f) because the ASID entry is still being torn down.

This is likely a DSP firmware issue where the ASID teardown is not completed synchronously before acknowledging the INIT_RELEASE. As a workaround, flush the IOMMU TLB for the session's SMMU context bank immediately after sending INIT_RELEASE. The SMMU hardware TLB invalidation broadcast acts as a synchronization point that causes the DSP firmware to complete its ASID teardown synchronously before the flush returns, eliminating the reuse race.

Workaround will be reverted once the fix is provided in Fastrpc driver/ Dsp Firmware side.