### PR TITLE
arm64: dts: qcom: Fix pm4125 vbus regulator compatible and constraints

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm4125.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm4125.dtsi
@@ -37,7 +37,7 @@
 		};
 
 		pm4125_vbus: usb-vbus-regulator@1100 {
-			compatible = "qcom,pm4125-vbus-reg", "qcom,pm8150b-vbus-reg";
+			compatible = "qcom,pm4125-vbus-reg";
 			reg = <0x1100>;
 			status = "disabled";
 		};

--- a/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
@@ -163,8 +163,8 @@
 };
 
 &pm4125_vbus {
-	regulator-min-microamp = <500000>;
-	regulator-max-microamp = <500000>;
+	regulator-min-microvolt = <4250000>;
+	regulator-max-microvolt = <5000000>;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-som.dtsi
@@ -164,8 +164,8 @@
 };
 
 &pm4125_vbus {
-	regulator-min-microamp = <500000>;
-	regulator-max-microamp = <500000>;
+	regulator-min-microvolt = <4250000>;
+	regulator-max-microvolt = <5000000>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Remove pm8150b fallback compatible from pm4125_vbus and fix regulator constraints in shikra SOM DTS files to use microvolt instead of microamp.