### PR TITLE
drm/msm/a6xx: Add support for A704 GPU and dt-bindings: display/msm/gpu: Add support for A704 shikra GPU

### DIFF
--- a/Documentation/devicetree/bindings/display/msm/gpu.yaml
+++ b/Documentation/devicetree/bindings/display/msm/gpu.yaml
@@ -357,6 +357,7 @@ allOf:
               - qcom,adreno-610.0
               - qcom,adreno-619.1
               - qcom,adreno-07000200
+              - qcom,adreno-07000400
     then:
       properties:
         clocks:

--- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
@@ -1478,6 +1478,23 @@ static const struct adreno_info a7xx_gpus[] = {
 			{ 142, 3 },
 		),
 	}, {
+		.chip_ids = ADRENO_CHIP_IDS(0x07000400),
+		.family = ADRENO_6XX_GEN1, /* NOT a mistake! */
+		.fw = {
+			[ADRENO_FW_SQE] = "a702_sqe.fw",
+		},
+		.gmem = SZ_128K,
+		.inactive_period = DRM_MSM_INACTIVE_PERIOD,
+		.quirks = ADRENO_QUIRK_HAS_HW_APRIV,
+		.funcs = &a6xx_gmuwrapper_funcs,
+		.a6xx = &(const struct a6xx_info) {
+			.hwcg = a702_hwcg,
+			.protect = &a650_protect,
+			.gbif_cx = a640_gbif,
+			.gmu_cgc_mode = 0x00020202,
+			.prim_fifo_threshold = 0x0000c000,
+		},
+	}, {
 		.chip_ids = ADRENO_CHIP_IDS(0x07030001),
 		.family = ADRENO_7XX_GEN1,
 		.fw = {

--- a/drivers/gpu/drm/msm/adreno/a6xx_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_gpu.c
@@ -643,7 +643,7 @@ static void a6xx_set_hwcg(struct msm_gpu *gpu, bool state)
 		clock_cntl_on = 0x8aa8aa02;
 	else if (adreno_is_a610(adreno_gpu) || adreno_is_a612(adreno_gpu))
 		clock_cntl_on = 0xaaa8aa82;
-	else if (adreno_is_a702(adreno_gpu))
+	else if (adreno_is_a702(adreno_gpu) || adreno_is_a704(adreno_gpu))
 		clock_cntl_on = 0xaaaaaa82;
 	else
 		clock_cntl_on = 0x8aa8aa82;
@@ -793,7 +793,7 @@ static int a6xx_calc_ubwc_config(struct adreno_gpu *gpu)
 	if (adreno_is_7c3(gpu))
 		cfg->highest_bank_bit = 14;
 
-	if (adreno_is_a702(gpu))
+	if (adreno_is_a702(gpu) || adreno_is_a704(gpu))
 		cfg->highest_bank_bit = 14;
 
 	if (cfg->highest_bank_bit != common_cfg->highest_bank_bit)
@@ -832,7 +832,8 @@ static void a6xx_set_ubwc_config(struct msm_gpu *gpu)
 	if (adreno_is_a650_family(adreno_gpu) || adreno_is_a7xx(adreno_gpu))
 		uavflagprd_inv = 2;
 
-	if (adreno_is_a610(adreno_gpu) || adreno_is_a702(adreno_gpu))
+	if (adreno_is_a610(adreno_gpu) || adreno_is_a702(adreno_gpu) ||
+	    adreno_is_a704(adreno_gpu))
 		min_acc_len_64b = true;
 
 	gpu_write(gpu, REG_A6XX_RB_NC_MODE_CNTL,
@@ -1067,7 +1068,8 @@ static bool a6xx_ucode_check_version(struct a6xx_gpu *a6xx_gpu,
 		return false;
 
 	/* A7xx is safe! */
-	if (adreno_is_a7xx(adreno_gpu) || adreno_is_a702(adreno_gpu) || adreno_is_a8xx(adreno_gpu))
+	if (adreno_is_a7xx(adreno_gpu) || adreno_is_a702(adreno_gpu) ||
+	    adreno_is_a704(adreno_gpu) || adreno_is_a8xx(adreno_gpu))
 		return true;
 
 	/*
@@ -1350,6 +1352,7 @@ static int hw_init(struct msm_gpu *gpu)
 
 	if (!(adreno_is_a650_family(adreno_gpu) ||
 	      adreno_is_a702(adreno_gpu) ||
+	      adreno_is_a704(adreno_gpu) ||
 	      adreno_is_a730(adreno_gpu))) {
 		gmem_range_min = adreno_is_a740_family(adreno_gpu) ? SZ_16M : SZ_1M;
 
@@ -1385,7 +1388,7 @@ static int hw_init(struct msm_gpu *gpu)
 	if (adreno_is_a610(adreno_gpu) || adreno_is_a612(adreno_gpu)) {
 		gpu_write(gpu, REG_A6XX_CP_MEM_POOL_SIZE, 48);
 		gpu_write(gpu, REG_A6XX_CP_MEM_POOL_DBG_ADDR, 47);
-	} else if (adreno_is_a702(adreno_gpu)) {
+	} else if (adreno_is_a702(adreno_gpu) || adreno_is_a704(adreno_gpu)) {
 		gpu_write(gpu, REG_A6XX_CP_MEM_POOL_SIZE, 64);
 		gpu_write(gpu, REG_A6XX_CP_MEM_POOL_DBG_ADDR, 63);
 	} else if (!adreno_is_a7xx(adreno_gpu))
@@ -1423,7 +1426,8 @@ static int hw_init(struct msm_gpu *gpu)
 		gpu_write(gpu, REG_A6XX_RBBM_INTERFACE_HANG_INT_CNTL, (1 << 30) | 0x4fffff);
 	else if (adreno_is_a619(adreno_gpu))
 		gpu_write(gpu, REG_A6XX_RBBM_INTERFACE_HANG_INT_CNTL, (1 << 30) | 0x3fffff);
-	else if (adreno_is_a610(adreno_gpu) || adreno_is_a702(adreno_gpu))
+	else if (adreno_is_a610(adreno_gpu) || adreno_is_a702(adreno_gpu) ||
+		 adreno_is_a704(adreno_gpu))
 		gpu_write(gpu, REG_A6XX_RBBM_INTERFACE_HANG_INT_CNTL, (1 << 30) | 0x3ffff);
 	else
 		gpu_write(gpu, REG_A6XX_RBBM_INTERFACE_HANG_INT_CNTL, (1 << 30) | 0x1fffff);
@@ -1459,7 +1463,7 @@ static int hw_init(struct msm_gpu *gpu)
 		else
 			gpu_write(gpu, REG_A6XX_CP_CHICKEN_DBG, 0x1);
 		gpu_write(gpu, REG_A6XX_RBBM_GBIF_CLIENT_QOS_CNTL, 0x0);
-	} else if (adreno_is_a702(adreno_gpu)) {
+	} else if (adreno_is_a702(adreno_gpu) || adreno_is_a704(adreno_gpu)) {
 		/* Something to do with the HLSQ cluster */
 		gpu_write(gpu, REG_A6XX_CP_CHICKEN_DBG, BIT(24));
 	}

--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.h
+++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
@@ -501,13 +501,19 @@ static inline int adreno_is_a702(const struct adreno_gpu *gpu)
 	return gpu->info->chip_ids[0] == 0x07000200;
 }
 
+static inline int adreno_is_a704(const struct adreno_gpu *gpu)
+{
+	return gpu->info->chip_ids[0] == 0x07000400;
+}
+
 static inline int adreno_is_a610_family(const struct adreno_gpu *gpu)
 {
 	if (WARN_ON_ONCE(!gpu->info))
 		return false;
 	return adreno_is_a610(gpu) ||
 	       adreno_is_a612(gpu) ||
-	       adreno_is_a702(gpu);
+	       adreno_is_a702(gpu) ||
+	       adreno_is_a704(gpu);
 }
 
 /* TODO: 615/616 */


### PR DESCRIPTION
drm/msm/a6xx: Add support for A704 GPU

Add support for the Adreno A704 GPU (chip ID 0x07000400). It belongs to
the A610 family and shares its configuration with the A702,
including firmware, HWCG, UBWC settings, and CP memory pool size.

Introduce adreno_is_a704() and include A704 in adreno_is_a610_family().


dt-bindings: display/msm/gpu: Add support for A704 shikra GPU

The Shikra SoC uses an Adreno A704 GPU identified by chip ID
0x07000400.

