### PR TITLE
arm64: dts: qcom: shikra: Enable MPSS remoteproc

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -105,6 +105,12 @@
 	status = "okay";
 };
 
+&remoteproc_mpss {
+        firmware-name = "qcom/shikra/qdsp6sw.mbn";
+
+        status = "okay";
+};
+
 &sdhc_1 {
 	vmmc-supply = <&pm4125_l20>;
 	vqmmc-supply = <&pm4125_l14>;

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -57,6 +57,12 @@
 	status = "okay";
 };
 
+&remoteproc_mpss {
+        firmware-name = "qcom/shikra/qdsp6sw.mbn";
+
+        status = "okay";
+};
+
 &sdhc_1 {
 	vmmc-supply = <&pm8150_l17>;
 	vqmmc-supply = <&pm8150_s4>;


### PR DESCRIPTION

Enable the Modem Processor SubSystem (MPSS) remoteproc on Shikra CQS
and IQS EVK boards

Signed-off-by: Anurag Pateriya <apateriy@qti.qualcomm.com>