### PR TITLE
arm64: dts: qcom: shikra: Add BAM-DMUX support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -24,6 +24,23 @@
 	#address-cells = <2>;
 	#size-cells = <2>;
 
+	bam_dmux: bam-dmux {
+		compatible = "qcom,bam-dmux";
+
+		interrupts-extended =
+			<&modem_smsm 1 IRQ_TYPE_EDGE_BOTH>,
+			<&modem_smsm 11 IRQ_TYPE_EDGE_BOTH>;
+		interrupt-names = "pc", "pc-ack";
+
+		qcom,smem-states =
+			<&apps_smsm 1>,
+			<&apps_smsm 11>;
+		qcom,smem-state-names = "pc", "pc-ack";
+
+		dmas = <&bam_dmux_dma 4>, <&bam_dmux_dma 5>;
+		dma-names = "tx", "rx";
+	};
+
 	clocks {
 		xo_board: xo-board {
 			compatible = "fixed-clock";
@@ -413,6 +430,28 @@
 
 		modem_smp2p_in: slave-kernel {
 			qcom,entry-name = "slave-kernel";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+	};
+
+	smsm {
+		compatible = "qcom,smsm";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		mboxes = <0>, <&apcs_glb 13>;
+
+		apps_smsm: apps@0 {
+			reg = <0>;
+			#qcom,smem-state-cells = <1>;
+		};
+
+		modem_smsm: modem@1 {
+			reg = <1>;
+			interrupts = <GIC_SPI 69 IRQ_TYPE_EDGE_RISING>;
+
 			interrupt-controller;
 			#interrupt-cells = <2>;
 		};
@@ -2544,6 +2583,18 @@
 
 				status = "disabled";
 			};
+		};
+
+		bam_dmux_dma: dma-controller@6044000 {
+			compatible = "qcom,bam-v1.7.0";
+			reg = <0x0 0x06044000 0x0 0x19000>;
+			interrupts = <GIC_SPI 74 IRQ_TYPE_EDGE_RISING>;
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+
+			num-channels = <6>;
+			qcom,num-ees = <1>;
+			qcom,powered-remotely;
 		};
 
 		remoteproc_mpss: remoteproc@6080000 {


### PR DESCRIPTION
Add required nodes to enable the upstream BAM-DMUX WWAN driver on Shikra.

The SMSM (Shared Memory State Machine) node provides the power control signaling between the AP and modem for BAM-DMUX. The BAM DMA controller node describes the A2 modem BAM hardware as a standard DMA controller. The BAM-DMUX node references the DMA channels and the pc/pc-ack interrupt lines from the modem SMSM entry for power control signaling.