### PR TITLE
PENDING: media: qcom: iris: move hwmode setup into power_on_hw sequence

### DIFF
--- a/drivers/media/platform/qcom/iris/iris_vpu3x.c
+++ b/drivers/media/platform/qcom/iris/iris_vpu3x.c
@@ -420,7 +420,6 @@ const struct vpu_ops iris_vpu3_ops = {
 	.power_off_controller = iris_vpu_power_off_controller,
 	.power_on_controller = iris_vpu_power_on_controller,
 	.calc_freq = iris_vpu3x_vpu4x_calculate_frequency,
-	.set_hwmode = iris_vpu_set_hwmode,
 };
 
 const struct vpu_ops iris_vpu3_purwa_ops = {

--- a/drivers/media/platform/qcom/iris/iris_vpu_common.c
+++ b/drivers/media/platform/qcom/iris/iris_vpu_common.c
@@ -291,8 +291,14 @@ int iris_vpu_power_on_hw(struct iris_core *core)
 	if (ret && ret != -ENOENT)
 		goto err_disable_hw_clock;
 
+	ret = iris_genpd_set_hwmode(core, IRIS_VCODEC_POWER_DOMAIN, true);
+	if (ret)
+		goto err_disable_hw_ahb_clock;
+
 	return 0;
 
+err_disable_hw_ahb_clock:
+	iris_disable_unprepare_clock(core, IRIS_VCODEC_AHB_CLK);
 err_disable_hw_clock:
 	iris_disable_unprepare_clock(core, IRIS_VCODEC_CLK);
 err_disable_power:
@@ -308,6 +314,9 @@ int iris_vpu_set_hwmode(struct iris_core *core)
 
 int iris_vpu_switch_to_hwmode(struct iris_core *core)
 {
+	if (!core->iris_platform_data->vpu_ops->set_hwmode)
+		return 0;
+
 	return core->iris_platform_data->vpu_ops->set_hwmode(core);
 }
 


### PR DESCRIPTION
Call iris_genpd_set_hwmode() directly in iris_vpu_power_on_hw()
instead of relying on the set_hwmode vpu_op callback. This ensures
hwmode is configured as part of the power-on sequence with proper
error handling, including unwinding the AHB clock on failure.

Remove set_hwmode from iris_vpu3_ops since it is now handled
in the common power-on path. Add a NULL check in
iris_vpu_switch_to_hwmode() to safely handle platforms that
do not implement this op.