### PR TITLE
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add WCD headset playback…

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
@@ -6,6 +6,7 @@
 /dts-v1/;
 /plugin/;
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/sound/qcom,q6afe.h>
 #include <dt-bindings/clock/qcom,gcc-sc7280.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
@@ -37,6 +38,29 @@
 
 };
 / {
+	wcd9370: audio-codec {
+		compatible = "qcom,wcd9370-codec";
+
+		pinctrl-0 = <&wcd_default>;
+		pinctrl-names = "default";
+
+		reset-gpios = <&tlmm 83 GPIO_ACTIVE_LOW>;
+		vdd-buck-supply = <&vph_pwr>;
+		vdd-rxtx-supply = <&vph_pwr>;
+		vdd-px-supply = <&vph_pwr>;
+		vdd-mic-bias-supply = <&vph_pwr>;
+		qcom,micbias1-microvolt = <1800000>;
+		qcom,micbias2-microvolt = <1800000>;
+		qcom,micbias3-microvolt = <1800000>;
+		qcom,micbias4-microvolt = <1800000>;
+		qcom,hphl-jack-type-normally-closed = <1>;
+		qcom,ground-jack-type-normally-closed = <1>;
+		qcom,rx-device = <&wcd937x_rx>;
+		qcom,tx-device = <&wcd937x_tx>;
+
+		#sound-dai-cells = <1>;
+	};
+
 
 	hdmi-connector {
 		status = "disabled";
@@ -136,6 +160,14 @@
 
 &lt9611_codec {
 	status = "disabled";
+};
+
+&lpass_rx_macro {
+	status = "okay";
+};
+
+&lpass_tx_macro {
+	status = "okay";
 };
 
 &mdss_dsi0_out {
@@ -350,6 +382,101 @@
 	};
 };
 
+&sound {
+	model = "qcs6490-rb3gen2-ia-snd-card";
+	audio-routing = "SpkrLeft IN", "WSA_SPK1 OUT",
+		"SpkrRight IN", "WSA_SPK2 OUT",
+		"IN1_HPHL", "HPHL_OUT",
+		"IN2_HPHR", "HPHR_OUT",
+		"AMIC2", "MIC BIAS2",
+		"TX SWR_ADC1", "ADC2_OUTPUT",
+		"VA DMIC0", "vdd-micb",
+		"VA DMIC1", "vdd-micb",
+		"VA DMIC2", "vdd-micb",
+		"VA DMIC3", "vdd-micb";
+
+	wcd-capture-dai-link {
+		link-name = "WCD Capture";
+
+		codec {
+			sound-dai = <&wcd9370 1>, <&swr1 0>, <&lpass_tx_macro 0>;
+		};
+
+		cpu {
+			sound-dai = <&q6apmbedai TX_CODEC_DMA_TX_3>;
+		};
+
+		platform {
+			sound-dai = <&q6apm>;
+		};
+	};
+
+	wcd-playback-dai-link {
+		link-name = "WCD Playback";
+
+		codec {
+			sound-dai = <&wcd9370 0>, <&swr0 0>, <&lpass_rx_macro 0>;
+		};
+
+		cpu {
+			sound-dai = <&q6apmbedai RX_CODEC_DMA_RX_0>;
+		};
+
+		platform {
+			sound-dai = <&q6apm>;
+		};
+	};
+};
+
+&swr0 {
+	status = "okay";
+
+	wcd937x_rx: codec@0,4 {
+		compatible = "sdw20217010a00";
+		reg = <0 4>;
+
+		/*
+		* WCD9370 RX Port 1 (HPH_L/R)       <==>    SWR1 Port 1 (HPH_L/R)
+		* WCD9370 RX Port 2 (CLSH)          <==>    SWR1 Port 2 (CLSH)
+		* WCD9370 RX Port 3 (COMP_L/R)      <==>    SWR1 Port 3 (COMP_L/R)
+		* WCD9370 RX Port 4 (LO)            <==>    SWR1 Port 4 (LO)
+		* WCD9370 RX Port 5 (DSD_L/R)       <==>    SWR1 Port 5 (DSD)
+		*/
+		qcom,rx-port-mapping = <1 2 3 4 5>;
+
+		/*
+		* Static channels mapping between slave and master rx port channels.
+		* In the order of slave port channels, which is
+		* hph_l, hph_r, clsh, comp_l, comp_r, lo, dsd_r, dsd_l.
+		*/
+		qcom,rx-channel-mapping = /bits/ 8 <1 2 1 1 2 1 1 2>;
+	};
+};
+
+&swr1 {
+	status = "okay";
+		wcd937x_tx: codec@0,3 {
+		compatible = "sdw20217010a00";
+		reg = <0 3>;
+
+		/*
+		* WCD9370 TX Port 1 (ADC1)               <=> SWR2 Port 2
+		* WCD9370 TX Port 2 (ADC2, 3)            <=> SWR2 Port 2
+		* WCD9370 TX Port 3 (DMIC0,1,2,3 & MBHC) <=> SWR2 Port 3
+		* WCD9370 TX Port 4 (DMIC4,5,6,7)        <=> SWR2 Port 4
+		*/
+		qcom,tx-port-mapping = <1 1 2 3>;
+
+		/*
+		* Static channel mapping between slave and master tx port channels.
+		* In the order of slave port channels which is adc1, adc2, adc3,
+		* mic0, dmic1, mbhc, dmic2, dmic3, dmci4, dmic5, dmic6, dmic7.
+		*/
+		qcom,tx-channel-mapping = /bits/ 8 <1 2 1 1 2 3 3 4 1 2 3 4>;
+	};
+};
+
+
 &tlmm {
 	pcie0_tc9563_resx_n: pcie0-tc9563-resx-state {
 		pins = "gpio78";
@@ -389,6 +516,12 @@
 		output-enable;
 	};
 
+	wcd_default: wcd-reset-n-active-state {
+		pins = "gpio83";
+		function = "gpio";
+		drive-strength = <16>;
+		bias-disable;
+	};
 };
 
 &wifi {


### PR DESCRIPTION
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add WCD headset playbac and record for qcs6490-rb3gen2 industrial mezzanine

Add WCD playback and capture DAI link to sound node. Add WCD codec node and corresponding soundwire nodes to perform headset playback and record.

Link: https://lore.kernel.org/all/20260423071951.3181130-1-karthik.s@oss.qualcomm.com/#t

CRs-Fixed: 4514420