### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: Enable audio over DISPLAY-PORT

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -201,6 +201,22 @@
 				sound-dai = <&q6apm>;
 			};
 		};
+
+		dp0-dai-link {
+			link-name = "DisplayPort0 Playback";
+
+			codec {
+				sound-dai = <&mdss0_dp0>;
+			};
+
+			cpu {
+				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
 	};
 
 	usb0_vbus: regulator-usb0-vbus {


### PR DESCRIPTION
Add dailinks for DISPLAY-PORT to enable audio functionality on edp0.

Link: https://lore.kernel.org/all/20260413043713.1659-1-kumar.singh@oss.qualcomm.com/

Signed-off-by: Karthik S [karthik.s@oss.qualcomm.com](mailto:karthik.s@oss.qualcomm.com)

CRs-Fixed: 4502072