### PR TITLE
dt-bindings: interconnect: qcom-bwmon: Add Shikra cpu-bwmon compatible

### DIFF
--- a/Documentation/devicetree/bindings/interconnect/qcom,msm8998-bwmon.yaml
+++ b/Documentation/devicetree/bindings/interconnect/qcom,msm8998-bwmon.yaml
@@ -50,6 +50,7 @@ properties:
               - qcom,sa8775p-llcc-bwmon
               - qcom,sc7180-llcc-bwmon
               - qcom,sc8280xp-llcc-bwmon
+              - qcom,shikra-cpu-bwmon
               - qcom,sm6350-cpu-bwmon
               - qcom,sm8250-llcc-bwmon
               - qcom,sm8550-llcc-bwmon


### PR DESCRIPTION
Add the Qualcomm Shikra SoC compatible string for the CPU-to-DDR bandwidth monitor. Shikra has a BWMONv5 for CPU.