### PR TITLE
FROMLIST: arm64: dts: qcom: glymur: Configure DP endpoints for 2-lane operation

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -2509,7 +2509,6 @@
 			#clock-cells = <1>;
 			#phy-cells = <1>;
 
-			mode-switch;
 			orientation-switch;
 
 			status = "disabled";
@@ -2583,7 +2582,6 @@
 			#clock-cells = <1>;
 			#phy-cells = <1>;
 
-			mode-switch;
 			orientation-switch;
 
 			status = "disabled";
@@ -5545,6 +5543,7 @@
 						reg = <1>;
 
 						mdss_dp0_out: endpoint {
+							data-lanes = <0 1>;
 							remote-endpoint = <&usb_dp_qmpphy_dp_in>;
 						};
 					};
@@ -5636,6 +5635,7 @@
 						reg = <1>;
 
 						mdss_dp1_out: endpoint {
+							data-lanes = <0 1>;
 							remote-endpoint = <&usb_1_qmpphy_dp_in>;
 						};
 					};


### PR DESCRIPTION
Add explicit data-lanes to the MDSS DP output endpoints to enable
display port in 2 lanes configuration and disable the mode-switch
property from the USB QMP PHY node.