### PR TITLE
arm64: dts: qcom: Update cpufreq node for Shikra SoC

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -49,6 +49,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			clocks = <&cpufreq_hw 0>;
 			qcom,freq-domain = <&cpufreq_hw 0>;
 			#cooling-cells = <2>;
 		};
@@ -61,6 +62,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			clocks = <&cpufreq_hw 0>;
 			qcom,freq-domain = <&cpufreq_hw 0>;
 			#cooling-cells = <2>;
 		};
@@ -73,6 +75,7 @@
 			next-level-cache = <&l3>;
 			capacity-dmips-mhz = <1024>;
 			dynamic-power-coefficient = <100>;
+			clocks = <&cpufreq_hw 0>;
 			qcom,freq-domain = <&cpufreq_hw 0>;
 			#cooling-cells = <2>;
 		};
@@ -85,6 +88,7 @@
 			next-level-cache = <&l2_3>;
 			capacity-dmips-mhz = <1946>;
 			dynamic-power-coefficient = <486>;
+			clocks = <&cpufreq_hw 1>;
 			qcom,freq-domain = <&cpufreq_hw 1>;
 			#cooling-cells = <2>;
 
@@ -3969,7 +3973,7 @@
 		};
 
 		cpufreq_hw: cpufreq@fd91000 {
-			compatible = "qcom,shikra-cpufreq-rimps", "qcom,cpufreq-rimps";
+			compatible = "qcom,shikra-epss";
 			reg = <0x0 0x0fd91000 0x0 0x1000>,
 			      <0x0 0x0fd92000 0x0 0x1000>;
 			reg-names = "freq-domain0",
@@ -3984,6 +3988,7 @@
 					  "dcvsh-irq-1";
 
 			#freq-domain-cells = <1>;
+			#clock-cells = <1>;
 		};
 	};
 


### PR DESCRIPTION
Update the cpufreq sclaing node compatible as per the latest bindings.

PR for the bindings:
https://github.com/qualcomm-linux/kernel-topics/pull/1212