### PR TITLE
arm64: dts: qcom: shikra: Add gpio-reserved-ranges to tlmm

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -181,6 +181,8 @@
 };
 
 &tlmm {
+	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+
 	lcd_bias_en: lcd-bias-en-state {
 		pins = "gpio151";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -181,6 +181,8 @@
 };
 
 &tlmm {
+	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+
 	lcd_bias_en: lcd-bias-en-state {
 		pins = "gpio151";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -199,6 +199,8 @@
 };
 
 &tlmm {
+	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+
 	panel_rst_n: panel-rst-n-state {
 		pins = "gpio3";
 		function = "gpio";


### PR DESCRIPTION
Add gpio-reserved-ranges property to the tlmm node for all three Shikra EVK variants (CQM, CQS, IQS) to mark GPIOs used by the SoC internally and not available for general use.