### PR TITLE
smsm, bam-dmux: Add ftrace tracepoints for observability

### DIFF
--- a/drivers/net/wwan/Makefile
+++ b/drivers/net/wwan/Makefile
@@ -10,6 +10,7 @@ obj-$(CONFIG_WWAN_HWSIM) += wwan_hwsim.o
 
 obj-$(CONFIG_MHI_WWAN_CTRL) += mhi_wwan_ctrl.o
 obj-$(CONFIG_MHI_WWAN_MBIM) += mhi_wwan_mbim.o
+CFLAGS_qcom_bam_dmux.o := -I$(src)
 obj-$(CONFIG_QCOM_BAM_DMUX) += qcom_bam_dmux.o
 obj-$(CONFIG_RPMSG_WWAN_CTRL) += rpmsg_wwan_ctrl.o
 obj-$(CONFIG_IOSM) += iosm/

--- a/drivers/net/wwan/qcom_bam_dmux.c
+++ b/drivers/net/wwan/qcom_bam_dmux.c
@@ -22,6 +22,9 @@
 #include <linux/workqueue.h>
 #include <net/pkt_sched.h>
 
+#define CREATE_TRACE_POINTS
+#include "trace-bam-dmux.h"
+
 #define BAM_DMUX_BUFFER_SIZE		SZ_2K
 #define BAM_DMUX_HDR_SIZE		sizeof(struct bam_dmux_hdr)
 #define BAM_DMUX_MAX_DATA_SIZE		(BAM_DMUX_BUFFER_SIZE - BAM_DMUX_HDR_SIZE)
@@ -278,6 +281,7 @@ static int bam_dmux_netdev_open(struct net_device *netdev)
 	struct bam_dmux_netdev *bndev = netdev_priv(netdev);
 	int ret;
 
+	trace_bam_dmux_channel(bndev->dmux->dev, bndev->ch, "local_open");
 	ret = bam_dmux_send_cmd(bndev, BAM_DMUX_CMD_OPEN);
 	if (ret)
 		return ret;
@@ -290,6 +294,7 @@ static int bam_dmux_netdev_stop(struct net_device *netdev)
 {
 	struct bam_dmux_netdev *bndev = netdev_priv(netdev);
 
+	trace_bam_dmux_channel(bndev->dmux->dev, bndev->ch, "local_close");
 	netif_stop_queue(netdev);
 	bam_dmux_send_cmd(bndev, BAM_DMUX_CMD_CLOSE);
 	return 0;
@@ -542,6 +547,7 @@ static void bam_dmux_cmd_open(struct bam_dmux *dmux, struct bam_dmux_hdr *hdr)
 	struct net_device *netdev = dmux->netdevs[hdr->ch];
 
 	dev_dbg(dmux->dev, "open channel: %u\n", hdr->ch);
+	trace_bam_dmux_channel(dmux->dev, hdr->ch, "remote_open");
 
 	if (__test_and_set_bit(hdr->ch, dmux->remote_channels)) {
 		dev_warn(dmux->dev, "Channel already open: %u\n", hdr->ch);
@@ -561,6 +567,7 @@ static void bam_dmux_cmd_close(struct bam_dmux *dmux, struct bam_dmux_hdr *hdr)
 	struct net_device *netdev = dmux->netdevs[hdr->ch];
 
 	dev_dbg(dmux->dev, "close channel: %u\n", hdr->ch);
+	trace_bam_dmux_channel(dmux->dev, hdr->ch, "remote_close");
 
 	if (!__test_and_clear_bit(hdr->ch, dmux->remote_channels)) {
 		dev_err(dmux->dev, "Channel not open: %u\n", hdr->ch);
@@ -589,6 +596,8 @@ static void bam_dmux_rx_callback(void *data)
 		dev_dbg(dmux->dev, "Unsupported channel: %u\n", hdr->ch);
 		goto out;
 	}
+
+	trace_bam_dmux_rx(dmux->dev, hdr->ch, hdr->cmd, hdr->len);
 
 	switch (hdr->cmd) {
 	case BAM_DMUX_CMD_DATA:
@@ -624,16 +633,20 @@ static bool bam_dmux_power_on(struct bam_dmux *dmux)
 	if (IS_ERR(dmux->rx)) {
 		dev_err(dev, "Failed to request RX DMA channel: %pe\n", dmux->rx);
 		dmux->rx = NULL;
+		trace_bam_dmux_power(dev, true, false);
 		return false;
 	}
 	dmaengine_slave_config(dmux->rx, &dma_rx_conf);
 
 	for (i = 0; i < BAM_DMUX_NUM_SKB; i++) {
-		if (!bam_dmux_skb_dma_queue_rx(&dmux->rx_skbs[i], GFP_KERNEL))
+		if (!bam_dmux_skb_dma_queue_rx(&dmux->rx_skbs[i], GFP_KERNEL)) {
+			trace_bam_dmux_power(dev, true, false);
 			return false;
+		}
 	}
 	dma_async_issue_pending(dmux->rx);
 
+	trace_bam_dmux_power(dev, true, true);
 	return true;
 }
 
@@ -669,6 +682,7 @@ static void bam_dmux_power_off(struct bam_dmux *dmux)
 	}
 
 	bam_dmux_free_skbs(dmux->rx_skbs, DMA_FROM_DEVICE);
+	trace_bam_dmux_power(dmux->dev, false, true);
 }
 
 static irqreturn_t bam_dmux_pc_irq(int irq, void *data)
@@ -677,6 +691,7 @@ static irqreturn_t bam_dmux_pc_irq(int irq, void *data)
 	bool new_state = !dmux->pc_state;
 
 	dev_dbg(dmux->dev, "pc: %u\n", new_state);
+	trace_bam_dmux_pc(dmux->dev, dmux->pc_state, new_state);
 
 	if (new_state) {
 		if (bam_dmux_power_on(dmux))
@@ -722,8 +737,11 @@ static int __maybe_unused bam_dmux_runtime_resume(struct device *dev)
 
 	/* Wait until previous power down was acked */
 	if (!wait_for_completion_timeout(&dmux->pc_ack_completion,
-					 BAM_DMUX_REMOTE_TIMEOUT))
+					 BAM_DMUX_REMOTE_TIMEOUT)) {
+		trace_bam_dmux_resume_step(dev, "prev_ack", -ETIMEDOUT);
 		return -ETIMEDOUT;
+	}
+	trace_bam_dmux_resume_step(dev, "prev_ack", 0);
 
 	/* Vote for power state */
 	bam_dmux_pc_vote(dmux, true);
@@ -732,33 +750,42 @@ static int __maybe_unused bam_dmux_runtime_resume(struct device *dev)
 	if (!wait_for_completion_timeout(&dmux->pc_ack_completion,
 					 BAM_DMUX_REMOTE_TIMEOUT)) {
 		bam_dmux_pc_vote(dmux, false);
+		trace_bam_dmux_resume_step(dev, "ack", -ETIMEDOUT);
 		return -ETIMEDOUT;
 	}
+	trace_bam_dmux_resume_step(dev, "ack", 0);
 
 	/* Wait until we're up */
 	if (!wait_event_timeout(dmux->pc_wait, dmux->pc_state,
 				BAM_DMUX_REMOTE_TIMEOUT)) {
 		bam_dmux_pc_vote(dmux, false);
+		trace_bam_dmux_resume_step(dev, "bam_up", -ETIMEDOUT);
 		return -ETIMEDOUT;
 	}
+	trace_bam_dmux_resume_step(dev, "bam_up", 0);
 
 	/* Ensure that we actually initialized successfully */
 	if (!dmux->rx) {
 		bam_dmux_pc_vote(dmux, false);
+		trace_bam_dmux_resume_step(dev, "bam_up", -ENXIO);
 		return -ENXIO;
 	}
 
 	/* Request TX channel if necessary */
-	if (dmux->tx)
+	if (dmux->tx) {
+		trace_bam_dmux_resume_step(dev, "tx_chan", 0);
 		return 0;
+	}
 
 	dmux->tx = dma_request_chan(dev, "tx");
 	if (IS_ERR(dmux->tx)) {
 		dev_err(dev, "Failed to request TX DMA channel: %pe\n", dmux->tx);
 		dmux->tx = NULL;
 		bam_dmux_runtime_suspend(dev);
+		trace_bam_dmux_resume_step(dev, "tx_chan", -ENXIO);
 		return -ENXIO;
 	}
+	trace_bam_dmux_resume_step(dev, "tx_chan", 0);
 
 	return 0;
 }

--- a/drivers/net/wwan/trace-bam-dmux.h
+++ b/drivers/net/wwan/trace-bam-dmux.h
@@ -1,0 +1,169 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM qcom_bam_dmux
+
+#if !defined(__QCOM_BAM_DMUX_TRACE_H__) || defined(TRACE_HEADER_MULTI_READ)
+#define __QCOM_BAM_DMUX_TRACE_H__
+
+#include <linux/device.h>
+#include <linux/tracepoint.h>
+
+/*
+ * Fired at the top of bam_dmux_pc_irq() when the modem toggles its BAM
+ * power-control SMSM bit.
+ *   old_state: dmux->pc_state before the edge (0 = BAM was off)
+ *   new_state: !old_state (what we are transitioning to)
+ *
+ * Downstream equivalent (BAM_DMUX_LOG):
+ *   "bam_dmux_smsm_cb: 0x%08x -> 0x%08x" + "reconnect / disconnect / init"
+ */
+TRACE_EVENT(bam_dmux_pc,
+	TP_PROTO(const struct device *dev, bool old_state, bool new_state),
+	TP_ARGS(dev, old_state, new_state),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(bool,		old_state)
+		__field(bool,		new_state)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->old_state = old_state;
+		__entry->new_state = new_state;
+	),
+	TP_printk("%s: pc %s -> %s",
+		  __get_str(dev_name),
+		  __entry->old_state ? "on" : "off",
+		  __entry->new_state ? "on" : "off")
+);
+
+/*
+ * Fired at the end of bam_dmux_power_on() and bam_dmux_power_off() to
+ * record whether the BAM DMA channel setup/teardown succeeded.
+ *   on:      true = power_on, false = power_off
+ *   success: only meaningful when on=true; false means DMA channel
+ *            request or RX buffer queueing failed
+ *
+ * Downstream equivalent:
+ *   "reconnect_to_bam: disconnect tx/rx, device reset, sps_connect tx/rx"
+ *   "disconnect_to_bam: disconnect tx, disconnect rx, device reset"
+ */
+TRACE_EVENT(bam_dmux_power,
+	TP_PROTO(const struct device *dev, bool on, bool success),
+	TP_ARGS(dev, on, success),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(bool,		on)
+		__field(bool,		success)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->on      = on;
+		__entry->success = success;
+	),
+	TP_printk("%s: power %s%s",
+		  __get_str(dev_name),
+		  __entry->on ? "on" : "off",
+		  __entry->on ? (__entry->success ? " ok" : " failed") : "")
+);
+
+/*
+ * Fired at the completion of each step inside bam_dmux_runtime_resume().
+ * result=0 means the step passed; negative errno means it failed/timed out.
+ *
+ * Steps in order:
+ *   "prev_ack"  - waited for previous power-down to be acked by modem
+ *   "ack"       - voted for power and waited for modem's ack
+ *   "bam_up"    - waited for modem to signal BAM is powered (pc_state=true)
+ *   "tx_chan"   - requested TX DMA channel
+ *
+ * Downstream equivalent (BAM_DMUX_LOG):
+ *   "ul_wakeup waiting for previous ack"
+ *   "ul_wakeup waiting for wakeup ack"
+ *   "ul_wakeup waiting completion"
+ *   "ul_wakeup complete"
+ */
+TRACE_EVENT(bam_dmux_resume_step,
+	TP_PROTO(const struct device *dev, const char *step, int result),
+	TP_ARGS(dev, step, result),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__string(step,		step)
+		__field(int,		result)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__assign_str(step);
+		__entry->result = result;
+	),
+	TP_printk("%s: resume %s: %d",
+		  __get_str(dev_name), __get_str(step), __entry->result)
+);
+
+/*
+ * Fired on every channel open and close event, from both the modem side
+ * (CMD_OPEN/CMD_CLOSE) and the local netdev side (ndo_open/ndo_stop).
+ *
+ * event: "remote_open"  - modem sent CMD_OPEN
+ *        "remote_close" - modem sent CMD_CLOSE
+ *        "local_open"   - AP opened the netdev (sent CMD_OPEN to modem)
+ *        "local_close"  - AP stopped the netdev (sent CMD_CLOSE to modem)
+ *
+ * Downstream equivalent (BAM_DMUX_LOG / BAM_DMUX_INFO):
+ *   "handle_bam_mux_cmd: opening cid N PC enabled"
+ *   "msm_bam_dmux_open: opening/opened ch N"
+ *   "msm_bam_dmux_close: closing/closed ch N"
+ */
+TRACE_EVENT(bam_dmux_channel,
+	TP_PROTO(const struct device *dev, u8 ch, const char *event),
+	TP_ARGS(dev, ch, event),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(u8,		ch)
+		__string(event,		event)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->ch = ch;
+		__assign_str(event);
+	),
+	TP_printk("%s: ch %u %s",
+		  __get_str(dev_name), __entry->ch, __get_str(event))
+);
+
+/*
+ * Fired in bam_dmux_rx_callback() for every valid inbound packet after
+ * magic and channel validation. For data packets, len is the payload
+ * length. For control packets (OPEN/CLOSE), len is 0.
+ *
+ * Downstream equivalent (BAM_DMUX_INFO via handle_bam_mux_cmd):
+ *   "handle_bam_mux_cmd: magic 33fc signal %x cmd %d pad %d ch %d len %d"
+ */
+TRACE_EVENT(bam_dmux_rx,
+	TP_PROTO(const struct device *dev, u8 ch, u8 cmd, u16 len),
+	TP_ARGS(dev, ch, cmd, len),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(u8,		ch)
+		__field(u8,		cmd)
+		__field(u16,		len)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->ch  = ch;
+		__entry->cmd = cmd;
+		__entry->len = len;
+	),
+	TP_printk("%s: rx ch %u cmd %u len %u",
+		  __get_str(dev_name), __entry->ch, __entry->cmd, __entry->len)
+);
+
+#endif /* __QCOM_BAM_DMUX_TRACE_H__ */
+
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH .
+
+#undef TRACE_INCLUDE_FILE
+#define TRACE_INCLUDE_FILE trace-bam-dmux
+
+#include <trace/define_trace.h>

--- a/drivers/soc/qcom/Makefile
+++ b/drivers/soc/qcom/Makefile
@@ -27,6 +27,7 @@ obj-$(CONFIG_QCOM_SMEM) +=	smem.o
 obj-$(CONFIG_QCOM_SMEM_STATE) += smem_state.o
 CFLAGS_smp2p.o := -I$(src)
 obj-$(CONFIG_QCOM_SMP2P)	+= smp2p.o
+CFLAGS_smsm.o := -I$(src)
 obj-$(CONFIG_QCOM_SMSM)	+= smsm.o
 obj-$(CONFIG_QCOM_SOCINFO)	+= socinfo.o
 obj-$(CONFIG_QCOM_SPM)		+= spm.o

--- a/drivers/soc/qcom/smsm.c
+++ b/drivers/soc/qcom/smsm.c
@@ -15,6 +15,9 @@
 #include <linux/soc/qcom/smem.h>
 #include <linux/soc/qcom/smem_state.h>
 
+#define CREATE_TRACE_POINTS
+#include "trace-smsm.h"
+
 /*
  * This driver implements the Qualcomm Shared Memory State Machine, a mechanism
  * for communicating single bit state information to remote processors.
@@ -162,6 +165,9 @@ static int smsm_update_bits(void *data, u32 mask, u32 value)
 
 	/* Don't signal if we didn't change the value */
 	changes = val ^ orig;
+
+	trace_smsm_update_bits(smsm->dev, mask, value, orig, val, changes);
+
 	if (!changes) {
 		spin_unlock_irqrestore(&smsm->lock, flags);
 		goto done;
@@ -181,6 +187,8 @@ static int smsm_update_bits(void *data, u32 mask, u32 value)
 		val = readl(smsm->subscription + host);
 		if (!(val & changes))
 			continue;
+
+		trace_smsm_ipc_kick(smsm->dev, host, val);
 
 		if (hostp->mbox_chan) {
 			mbox_send_message(hostp->mbox_chan, NULL);
@@ -214,10 +222,14 @@ static irqreturn_t smsm_intr(int irq, void *data)
 	unsigned i;
 	int irq_pin;
 	u32 changed;
+	u32 old;
 	u32 val;
 
 	val = readl(entry->remote_state);
-	changed = val ^ xchg(&entry->last_value, val);
+	old = xchg(&entry->last_value, val);
+	changed = val ^ old;
+
+	trace_smsm_intr(irq, old, val, changed);
 
 	for_each_set_bit(i, entry->irq_enabled, 32) {
 		if (!(changed & BIT(i)))
@@ -226,11 +238,13 @@ static irqreturn_t smsm_intr(int irq, void *data)
 		if (val & BIT(i)) {
 			if (test_bit(i, entry->irq_rising)) {
 				irq_pin = irq_find_mapping(entry->domain, i);
+				trace_smsm_irq_cascade(irq_pin, i, true);
 				handle_nested_irq(irq_pin);
 			}
 		} else {
 			if (test_bit(i, entry->irq_falling)) {
 				irq_pin = irq_find_mapping(entry->domain, i);
+				trace_smsm_irq_cascade(irq_pin, i, false);
 				handle_nested_irq(irq_pin);
 			}
 		}
@@ -257,6 +271,7 @@ static void smsm_mask_irq(struct irq_data *irqd)
 		val = readl(entry->subscription + smsm->local_host);
 		val &= ~BIT(irq);
 		writel(val, entry->subscription + smsm->local_host);
+		trace_smsm_irq_mask(irq, true, val);
 	}
 
 	clear_bit(irq, entry->irq_enabled);
@@ -288,6 +303,7 @@ static void smsm_unmask_irq(struct irq_data *irqd)
 		val = readl(entry->subscription + smsm->local_host);
 		val |= BIT(irq);
 		writel(val, entry->subscription + smsm->local_host);
+		trace_smsm_irq_mask(irq, false, val);
 	}
 }
 

--- a/drivers/soc/qcom/trace-smsm.h
+++ b/drivers/soc/qcom/trace-smsm.h
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM qcom_smsm
+
+#if !defined(__QCOM_SMSM_TRACE_H__) || defined(TRACE_HEADER_MULTI_READ)
+#define __QCOM_SMSM_TRACE_H__
+
+#include <linux/device.h>
+#include <linux/tracepoint.h>
+
+/*
+ * Fired on every call to smsm_update_bits(), whether or not the state
+ * actually changed.  changes == 0 indicates the write was a no-op because
+ * the bits were already in the requested state.
+ */
+TRACE_EVENT(smsm_update_bits,
+	TP_PROTO(const struct device *dev, u32 mask, u32 value,
+		 u32 orig, u32 val, u32 changes),
+	TP_ARGS(dev, mask, value, orig, val, changes),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(u32,		mask)
+		__field(u32,		value)
+		__field(u32,		orig)
+		__field(u32,		val)
+		__field(u32,		changes)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->mask    = mask;
+		__entry->value   = value;
+		__entry->orig    = orig;
+		__entry->val     = val;
+		__entry->changes = changes;
+	),
+	TP_printk("%s: mask:0x%08x value:0x%08x 0x%08x->0x%08x changed:0x%08x",
+		  __get_str(dev_name),
+		  __entry->mask, __entry->value,
+		  __entry->orig, __entry->val,
+		  __entry->changes)
+);
+
+/*
+ * Fired for each remote host that is subscribed to the changed bits and
+ * is about to receive an IPC kick.
+ */
+TRACE_EVENT(smsm_ipc_kick,
+	TP_PROTO(const struct device *dev, u32 host, u32 subscription),
+	TP_ARGS(dev, host, subscription),
+	TP_STRUCT__entry(
+		__string(dev_name,	dev_name(dev))
+		__field(u32,		host)
+		__field(u32,		subscription)
+	),
+	TP_fast_assign(
+		__assign_str(dev_name);
+		__entry->host         = host;
+		__entry->subscription = subscription;
+	),
+	TP_printk("%s: kick host %u subscription:0x%08x",
+		  __get_str(dev_name), __entry->host, __entry->subscription)
+);
+
+/*
+ * Fired at the top of smsm_intr() after reading the remote state and
+ * computing the changed bits.
+ */
+TRACE_EVENT(smsm_intr,
+	TP_PROTO(int irq, u32 old_state, u32 new_state, u32 changed),
+	TP_ARGS(irq, old_state, new_state, changed),
+	TP_STRUCT__entry(
+		__field(int,	irq)
+		__field(u32,	old_state)
+		__field(u32,	new_state)
+		__field(u32,	changed)
+	),
+	TP_fast_assign(
+		__entry->irq       = irq;
+		__entry->old_state = old_state;
+		__entry->new_state = new_state;
+		__entry->changed   = changed;
+	),
+	TP_printk("IRQ %d: 0x%08x->0x%08x changed:0x%08x",
+		  __entry->irq,
+		  __entry->old_state, __entry->new_state,
+		  __entry->changed)
+);
+
+/*
+ * Fired for each cascaded (per-bit) IRQ that is about to be dispatched
+ * to a downstream consumer (e.g. the BAM DMUX pc/pc-ack handler).
+ */
+TRACE_EVENT(smsm_irq_cascade,
+	TP_PROTO(int irq_pin, unsigned int bit, bool rising),
+	TP_ARGS(irq_pin, bit, rising),
+	TP_STRUCT__entry(
+		__field(int,		irq_pin)
+		__field(unsigned int,	bit)
+		__field(bool,		rising)
+	),
+	TP_fast_assign(
+		__entry->irq_pin = irq_pin;
+		__entry->bit     = bit;
+		__entry->rising  = rising;
+	),
+	TP_printk("IRQ %d bit %u %s",
+		  __entry->irq_pin, __entry->bit,
+		  __entry->rising ? "rising" : "falling")
+);
+
+/*
+ * Fired when a cascaded per-bit IRQ is masked or unmasked, recording the
+ * resulting subscription bitmap written to shared memory.
+ */
+TRACE_EVENT(smsm_irq_mask,
+	TP_PROTO(unsigned long irq, bool mask, u32 subscription),
+	TP_ARGS(irq, mask, subscription),
+	TP_STRUCT__entry(
+		__field(unsigned long,	irq)
+		__field(bool,		mask)
+		__field(u32,		subscription)
+	),
+	TP_fast_assign(
+		__entry->irq          = irq;
+		__entry->mask         = mask;
+		__entry->subscription = subscription;
+	),
+	TP_printk("IRQ %lu %s subscription:0x%08x",
+		  __entry->irq,
+		  __entry->mask ? "masked" : "unmasked",
+		  __entry->subscription)
+);
+
+#endif /* __QCOM_SMSM_TRACE_H__ */
+
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH .
+
+#undef TRACE_INCLUDE_FILE
+#define TRACE_INCLUDE_FILE trace-smsm
+
+#include <trace/define_trace.h>


### PR DESCRIPTION
Add ftrace tracepoints to the SMSM and BAM-DMUX drivers to improve observability of the modem IPC stack on Shikra.

The SMSM tracepoints cover state bit updates, IPC kicks, interrupt handling, and IRQ mask/unmask operations. The BAM-DMUX tracepoints cover channel open/close (local and remote), RX callbacks, power on/off transitions, power control IRQs, and each step of the runtime resume sequence.

Each patch introduces a trace header alongside its driver and wires the CFLAGS so the trace header is found via -I$(src), following the pattern used by existing upstreamed qualcomm traces like qcom_glink_trace.h.