### PR TITLE
arm64: dts: qcom: shikra-iqs-evk: Add DSI panel support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -42,6 +42,18 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
 	};
+
+	lcd_bias: regulator-lcd-bias {
+		compatible = "regulator-fixed";
+		regulator-name = "lcd_bias";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&pm8150_l17>;
+		gpio = <&pm8150_gpios 4 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-0 = <&lcd_bias_en>;
+		pinctrl-names = "default";
+	};
 };
 
 &gpu {
@@ -50,6 +62,60 @@
 
 &gpu_zap_shader {
 	firmware-name = "qcom/shikra/a704_zap.mbn";
+};
+
+&mdss {
+	status = "okay";
+};
+
+&mdss_dsi0 {
+	vdda-supply = <&pm8150_l11>;
+	status = "okay";
+
+	panel@0 {
+		compatible = "dlc,dlc0697";
+		reg = <0>;
+
+		reset-gpios = <&tlmm 3 GPIO_ACTIVE_LOW>;
+		enable-gpios = <&pm8150_gpios 1 GPIO_ACTIVE_HIGH>;
+
+		vddio-supply = <&pm8150_l15>;
+		bias-supply = <&lcd_bias>;
+
+		pinctrl-0 = <&panel_rst_n &panel_te_pin>;
+		pinctrl-1 = <&panel_rst_n_suspend>;
+		pinctrl-names = "default", "sleep";
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	remote-endpoint = <&panel_in>;
+	data-lanes = <0 1 2 3>;
+};
+
+&mdss_dsi0_phy {
+	status = "okay";
+};
+
+&pm8150_gpios {
+	lcd_bias_en: lcd-bias-en-state {
+		pins = "gpio4";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-disable;
+	};
+};
+
+&pm8150_l11 {
+	/* DSI VDDA - must be at NOM voltage for PHY PLL lock */
+	regulator-min-microvolt = <1232000>;
+	regulator-max-microvolt = <1232000>;
+	regulator-allow-set-load;
 };
 
 &remoteproc_cdsp {


### PR DESCRIPTION
Add lcd_bias fixed regulator (3.3V, controlled via pm8150 GPIO4)
Enable mdss, mdss_dsi0, mdss_dsi0_phy nodes
Add DLC DLC0697 panel node on DSI0 with reset/enable GPIOs, vddio/bias supplies, and TE pin
Configure mdss_dsi0_out with 4-lane data path
Set pm8150_l11 to 1232mV for DSI VDDA PHY PLL lock
Add tlmm pinctrl states for panel reset, reset-suspend, and TE pin
CRs-Fixed: 4549025