### PR TITLE
QCLINUX: arm64: dts: qcom:  Enable combo mode on CSI1&& Fix GPIO free and acquire logic 

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
@@ -125,7 +125,7 @@
 	};
 
 	/*cam0a-ov9282*/
-	rb8_slot0: qcom,cam-sensor1 {
+	qcom,cam-sensor1 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <0>;
 		sensor-position-roll = <0>;
@@ -439,7 +439,7 @@
 	};
 
 	/*cam1-ov9282*/
-	rb8_slot1: qcom,cam-sensor21 {
+	qcom,cam-sensor21 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <1>;
 		sensor-position-roll = <0>;
@@ -454,10 +454,8 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-			     &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-			     &cam_sensor_suspend_rst1>;
+		pinctrl-0 = <&cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_suspend_rst1>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 73 0>,
 			<&tlmm 133 0>,
@@ -475,47 +473,6 @@
 		clock-cntl-level = "nominal";
 		clock-rates = <24000000>;
 		cell-index = <21>;
-		status = "ok";
-	};
-
-	/*cam1-imx577*/
-	qcom,cam-sensor26 {
-		compatible = "qcom,cam-sensor";
-		csiphy-sd-index = <1>;
-		sensor-position-roll = <0>;
-		sensor-position-pitch = <0>;
-		sensor-position-yaw = <180>;
-		eeprom-src = <&eeprom_cam26>;
-		cam_vio-supply = <&vreg_s4a>;
-		regulator-names = "cam_vio";
-		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		rgltr-cntrl-support;
-		pwm-switch;
-		rgltr-min-voltage = <1800000>;
-		rgltr-max-voltage = <1800000>;
-		rgltr-load-current = <120000>;
-		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-		             &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-		             &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 73 0>,
-		        <&tlmm 133 0>,
-		        <&pmm8654au_0_gpios 8 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK1",
-		                     "CAMIF_RESET1",
-		                     "CAM_CUSTOM1";
-		cci-master = <0>;
-		clocks = <&camcc CAM_CC_MCLK1_CLK>;
-		clock-names = "cam_clk";
-		clock-cntl-level = "nominal";
-		clock-rates = <24000000>;
-		cell-index = <26>;
 		status = "ok";
 	};
 
@@ -560,8 +517,13 @@
 		status = "ok";
 	};
 
-	eeprom_cam26: qcom,eeprom26 {
-		compatible = "qcom,eeprom";
+	/*cam1-ov9282*/
+	qcom,cam-sensor31 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
 		cam_vio-supply = <&vreg_s4a>;
 		regulator-names = "cam_vio";
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
@@ -571,28 +533,22 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-		             &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-		             &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 73 0>,
-		        <&tlmm 133 0>,
+			<&expander2 2 0>,
 		        <&pmm8654au_0_gpios 8 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
 		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAMIF_MCLK1",
-		                     "CAM_RESET1",
+		gpio-req-tbl-label = "CAM_MCLK1",
+		                     "CAMIF_RESET1",
 		                     "CAM_CUSTOM1";
-		sensor-mode = <0>;
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK1_CLK>;
 		clock-names = "cam_clk";
 		clock-cntl-level = "nominal";
 		clock-rates = <24000000>;
-		cell-index = <26>;
+		cell-index = <31>;
 		status = "ok";
 	};
 
@@ -755,7 +711,7 @@
 	};
 
 	/*cam2-ov9282*/
-	rb8_slot2: qcom,cam-sensor22 {
+	qcom,cam-sensor22 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <2>;
 		sensor-position-roll = <0>;
@@ -994,7 +950,7 @@
 	};
 
 	/*cam3-ov9282*/
-	rb8_slot3: qcom,cam-sensor23 {
+	qcom,cam-sensor23 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <3>;
 		sensor-position-roll = <0>;
@@ -1115,6 +1071,11 @@
 	qcom,cam-res-mgr {
 		compatible = "qcom,cam-res-mgr";
 		gpios-shared = <518 519 520 521>;
+		gpios-shared-pinctrl = <633>;
+		shared-pctrl-gpio-names = "mclk1";
+		pinctrl-0 = <&cam_sensor_mclk1_active>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend>;
+		pinctrl-names = "mclk1_active", "mclk1_suspend";
 		status = "ok";
 	};
 };

--- a/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
@@ -125,7 +125,7 @@
 	};
 
 	/*cam0a-ov9282*/
-	qcom,cam-sensor1 {
+	rb8_slot0: qcom,cam-sensor1 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <0>;
 		sensor-position-roll = <0>;
@@ -140,20 +140,16 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk0_active
-			     &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend
-			     &cam_sensor_suspend_rst0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 72 0>,
-			<&tlmm 132 0>,
+		gpios =<&tlmm 132 0>,
 			<&pmm8654au_0_gpios 7 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK0",
-				     "CAMIF_RESET0",
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET0",
 				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
@@ -181,21 +177,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk0_active
-			     &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend
-			     &cam_sensor_suspend_rst0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 72 0>,
-			<&tlmm 132 0>,
+		gpios =<&tlmm 132 0>,
 			<&pmm8654au_0_gpios 7 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK0",
-				     "CAMIF_RESET0",
-			             "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
 		clock-names = "cam_clk";
@@ -222,21 +214,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk0_active
-		             &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend
-		             &cam_sensor_suspend_rst0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 72 0>,
-		        <&tlmm 132 0>,
+		gpios =<&tlmm 132 0>,
 		        <&pmm8654au_0_gpios 7 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK0",
-		                     "CAMIF_RESET0",
-		                     "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
 		clock-names = "cam_clk";
@@ -257,21 +245,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk0_active
-			     &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend
-			     &cam_sensor_suspend_rst0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 72 0>,
-			<&tlmm 132 0>,
+		gpios =<&tlmm 132 0>,
 			<&pmm8654au_0_gpios 7 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK0",
-			             "CAMIF_RESET0",
-			             "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
 		clock-names = "cam_clk";
@@ -292,20 +276,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk0_active
-		             &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend
-		             &cam_sensor_suspend_rst0>;
-		gpios = <&tlmm 72 0>,
-		        <&tlmm 132 0>,
+		pinctrl-0 = <&cam_sensor_mclk0_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios =<&tlmm 132 0>,
 		        <&pmm8654au_0_gpios 7 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK0",
-		                     "CAMIF_RESET0",
-		                     "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
 		sensor-mode = <0>;
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
@@ -439,7 +420,7 @@
 	};
 
 	/*cam1-ov9282*/
-	qcom,cam-sensor21 {
+	rb8_slot1: qcom,cam-sensor21 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <1>;
 		sensor-position-roll = <0>;
@@ -454,9 +435,6 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 73 0>,
 			<&tlmm 133 0>,
 			<&pmm8654au_0_gpios 8 0>;
@@ -493,11 +471,6 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-		             &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-		             &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 73 0>,
 		        <&tlmm 133 0>,
 		        <&pmm8654au_0_gpios 8 0>;
@@ -535,7 +508,7 @@
 		gpio-no-mux = <0>;
 		gpios = <&tlmm 73 0>,
 			<&expander2 2 0>,
-		        <&pmm8654au_0_gpios 8 0>;
+			<&pmm8654au_0_gpios 8 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -563,11 +536,6 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-		             &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-		             &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 73 0>,
 		        <&tlmm 133 0>,
 		        <&pmm8654au_0_gpios 8 0>;
@@ -711,7 +679,7 @@
 	};
 
 	/*cam2-ov9282*/
-	qcom,cam-sensor22 {
+	rb8_slot2: qcom,cam-sensor22 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <2>;
 		sensor-position-roll = <0>;
@@ -726,21 +694,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk2_active
-			     &cam_sensor_active_rst2>;
-		pinctrl-1 = <&cam_sensor_mclk2_suspend
-			     &cam_sensor_suspend_rst2>;
+		pinctrl-0 = <&cam_sensor_mclk2_active>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 74 0>,
-			<&tlmm 134 0>,
+		gpios = <&tlmm 134 0>,
 			<&pmm8654au_0_gpios 9 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK2",
-				     "CAMIF_RESET2",
-			             "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET2",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK2_CLK>;
 		clock-names = "cam_clk";
@@ -767,21 +731,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk2_active
-		             &cam_sensor_active_rst2>;
-		pinctrl-1 = <&cam_sensor_mclk2_suspend
-		             &cam_sensor_suspend_rst2>;
+		pinctrl-0 = <&cam_sensor_mclk2_active>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 74 0>,
-		        <&tlmm 134 0>,
+		gpios = <&tlmm 134 0>,
 		        <&pmm8654au_0_gpios 9 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK2",
-		                     "CAMIF_RESET2",
-		                     "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET2",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK2_CLK>;
 		clock-names = "cam_clk";
@@ -802,21 +762,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk2_active
-		             &cam_sensor_active_rst2>;
-		pinctrl-1 = <&cam_sensor_mclk2_suspend
-		             &cam_sensor_suspend_rst2>;
+		pinctrl-0 = <&cam_sensor_mclk2_active>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 74 0>,
-		        <&tlmm 134 0>,
+		gpios = <&tlmm 134 0>,
 		        <&pmm8654au_0_gpios 9 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAMIF_MCLK2",
-		                     "CAM_RESET2",
-		                     "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET2",
+				     "CAM_CUSTOM1";
 		sensor-mode = <0>;
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK2_CLK>;
@@ -950,7 +906,7 @@
 	};
 
 	/*cam3-ov9282*/
-	qcom,cam-sensor23 {
+	rb8_slot3: qcom,cam-sensor23 {
 		compatible = "qcom,cam-sensor";
 		csiphy-sd-index = <3>;
 		sensor-position-roll = <0>;
@@ -965,21 +921,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk3_active
-			     &cam_sensor_active_rst3>;
-		pinctrl-1 = <&cam_sensor_mclk3_suspend
-			     &cam_sensor_suspend_rst3>;
+		pinctrl-0 = <&cam_sensor_mclk3_active>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 75 0>,
-			<&tlmm 135 0>,
+		gpios = <&tlmm 135 0>,
 			<&pmm8654au_0_gpios 10 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK3",
-				     "CAMIF_RESET3",
-			             "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET3",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK3_CLK>;
 		clock-names = "cam_clk";
@@ -1006,21 +958,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk3_active>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		pinctrl-0 = <&cam_sensor_mclk3_active
-		            &cam_sensor_active_rst3>;
-		pinctrl-1 = <&cam_sensor_mclk3_suspend
-		            &cam_sensor_suspend_rst3>;
-		gpios = <&tlmm 75 0>,
-		        <&tlmm 135 0>,
+		gpios = <&tlmm 135 0>,
 		        <&pmm8654au_0_gpios 10 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK3",
-		                     "CAMIF_RESET3",
-		                     "CAM_CUSTOM1";
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET3",
+				     "CAM_CUSTOM1";
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK3_CLK>;
 		clock-names = "cam_clk";
@@ -1041,21 +989,17 @@
 		rgltr-max-voltage = <1800000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk3_active
-		             &cam_sensor_active_rst3>;
-		pinctrl-1 = <&cam_sensor_mclk3_suspend
-		             &cam_sensor_suspend_rst3>;
-		gpios = <&tlmm 75 0>,
-		        <&tlmm 135 0>,
-		        <&pmm8654au_0_gpios 10 0>;
+		pinctrl-0 = <&cam_sensor_mclk3_active>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAMIF_MCLK3",
-		                     "CAM_RESET3",
-		                     "CAM_CUSTOM1";
+		gpios = <&tlmm 135 0>,
+			<&pmm8654au_0_gpios 10 0>;
+		gpio-reset = <0>;
+		gpio-custom1 = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <0 0>;
+		gpio-req-tbl-label = "CAMIF_RESET3",
+				     "CAM_CUSTOM1";
 		sensor-mode = <0>;
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK3_CLK>;


### PR DESCRIPTION
In order to enable combo mode on CSI1 mode, resources needs to be in shared mode. This change adds required resources under res-mgr node.
And prevent GPIOs managed by pinctrl from being requested and freed via the GPIO framework. Restrict GPIO request/free operations to non-pinctrl GPIOs by adding appropriate conditions.

CRs-Fixed: 4515096
CRs-Fixed: 4503635