### PR TITLE
FROMLIST: arm64: dts: qcom: kodiak: Add GEM_NOC interconnect for adre…

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak.dtsi
+++ b/arch/arm64/boot/dts/qcom/kodiak.dtsi
@@ -3385,6 +3385,8 @@
 
 			power-domains = <&gpucc GPU_CC_CX_GDSC>;
 			dma-coherent;
+			interconnects = <&gem_noc MASTER_GPU_TCU QCOM_ICC_TAG_ALWAYS
+					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 		};
 
 		gfx_0_tbu: tbu@3dd9000 {


### PR DESCRIPTION
…no SMMU

On Kodiak platforms, the Adreno SMMU requires a bandwidth vote on the GEM_NOC path (MASTER_GPU_TCU -> SLAVE_EBI1) before its registers are accessible. Without this vote, the SMMU may become unreachable, leading to intermittent probe failures and runtime issues.

Add the required interconnect to ensure reliable register access.

Link: https://lore.kernel.org/all/20260526-smmu_interconnect_addition-v2-0-2a6d8ca30d63@oss.qualcomm.com/