### PR TITLE
FROMLIST: arm64: dts: qcom: monaco: Add GEM_NOC interconnect for adre…

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -5127,6 +5127,8 @@
 				      "gpu_cc_hub_aon_clk";
 			power-domains = <&gpucc GPU_CC_CX_GDSC>;
 			dma-coherent;
+			interconnects = <&gem_noc MASTER_GPU_TCU QCOM_ICC_TAG_ALWAYS
+					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 		};
 
 		pmu@9091000 {


### PR DESCRIPTION
…no SMMU

On Monaco platforms, the Adreno SMMU requires a bandwidth vote on the GEM_NOC path (MASTER_GPU_TCU -> SLAVE_EBI1) before its registers are accessible. Without this vote, the SMMU may become unreachable, leading to intermittent probe failures and runtime issues.

Add the required interconnect to ensure reliable register access.

Link: https://lore.kernel.org/all/20260526-smmu_interconnect_addition-v2-0-2a6d8ca30d63@oss.qualcomm.com/