### PR TITLE
FROMLIST: arm64: dts: qcom: qcs615-ride: fix sdhc_2 vqmmc-supply for …

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+++ b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
@@ -232,8 +232,8 @@
 
 		vreg_l2a: ldo2 {
 			regulator-name = "vreg_l2a";
-			regulator-min-microvolt = <1650000>;
-			regulator-max-microvolt = <3100000>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
 			regulator-allow-set-load;
 			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
@@ -606,7 +606,7 @@
 	cd-gpios = <&tlmm 99 GPIO_ACTIVE_LOW>;
 
 	vmmc-supply = <&vreg_l10a>;
-	vqmmc-supply = <&vreg_s4a>;
+	vqmmc-supply = <&vreg_l2a>;
 
 	status = "okay";
 };


### PR DESCRIPTION
SD card is detected as SDHS instead of UHS-I because sdhc_2 uses vreg_s4a as vqmmc-supply, which cannot switch between 1.8V and 3.3V.

Switch vqmmc-supply to vreg_l2a and update its voltage range to 1800000-2960000 uV to enable proper UHS-I signaling.

CRs-Fixed: 4513385