### PR TITLE
arm64: dts: qcom: shikra: Add wcn3988-pmu node to EVK boards

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -37,6 +37,34 @@
 		pinctrl-names = "default";
 	};
 
+	wcn3988-pmu {
+		compatible = "qcom,wcn3988-pmu";
+
+		vddio-supply = <&pm4125_l7>;
+		vddxo-supply = <&pm4125_l13>;
+		vddrf-supply = <&pm4125_l10>;
+		vddch0-supply = <&pm4125_l22>;
+
+		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+
+		regulators {
+			vreg_pmu_io: ldo0 {
+				regulator-name = "vreg_pmu_io";
+			};
+
+			vreg_pmu_xo: ldo1 {
+				regulator-name = "vreg_pmu_xo";
+			};
+
+			vreg_pmu_rf: ldo2 {
+				regulator-name = "vreg_pmu_rf";
+			};
+
+			vreg_pmu_ch0: ldo3 {
+				regulator-name = "vreg_pmu_ch0";
+			};
+		};
+	};
 };
 
 &gpu {
@@ -191,10 +219,10 @@
 	status = "okay";
 
 	bluetooth {
-		vddio-supply = <&pm4125_l7>;
-		vddxo-supply = <&pm4125_l13>;
-		vddrf-supply = <&pm4125_l10>;
-		vddch0-supply = <&pm4125_l22>;
+		vddio-supply = <&vreg_pmu_io>;
+		vddxo-supply = <&vreg_pmu_xo>;
+		vddrf-supply = <&vreg_pmu_rf>;
+		vddch0-supply = <&vreg_pmu_ch0>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -36,6 +36,35 @@
 		pinctrl-0 = <&lcd_bias_en>;
 		pinctrl-names = "default";
 	};
+
+	wcn3988-pmu {
+		compatible = "qcom,wcn3988-pmu";
+
+		vddio-supply = <&pm4125_l7>;
+		vddxo-supply = <&pm4125_l13>;
+		vddrf-supply = <&pm4125_l10>;
+		vddch0-supply = <&pm4125_l22>;
+
+		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+
+		regulators {
+			vreg_pmu_io: ldo0 {
+				regulator-name = "vreg_pmu_io";
+			};
+
+			vreg_pmu_xo: ldo1 {
+				regulator-name = "vreg_pmu_xo";
+			};
+
+			vreg_pmu_rf: ldo2 {
+				regulator-name = "vreg_pmu_rf";
+			};
+
+			vreg_pmu_ch0: ldo3 {
+				regulator-name = "vreg_pmu_ch0";
+			};
+		};
+	};
 };
 
 &gpu {
@@ -189,10 +218,10 @@
 	status = "okay";
 
 	bluetooth {
-		vddio-supply = <&pm4125_l7>;
-		vddxo-supply = <&pm4125_l13>;
-		vddrf-supply = <&pm4125_l10>;
-		vddch0-supply = <&pm4125_l22>;
+		vddio-supply = <&vreg_pmu_io>;
+		vddxo-supply = <&vreg_pmu_xo>;
+		vddrf-supply = <&vreg_pmu_rf>;
+		vddch0-supply = <&vreg_pmu_ch0>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
@@ -21,3 +21,12 @@
 	firmware-name = "qcom/shikra/qupv3fw.elf";
 	status = "okay";
 };
+
+&uart8 {
+
+	bluetooth {
+		compatible = "qcom,wcn3988-bt";
+
+		max-speed = <3200000>;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -35,9 +35,9 @@
 		};
 	};
 
-	vreg_bt_3p3_dummy: regulator-bt-3p3-dummy {
+	vreg_wcn_3p3: regulator-wcn-3p3 {
 		compatible = "regulator-fixed";
-		regulator-name = "bt_3p3_dummy";
+		regulator-name = "wcn_3p3";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
@@ -53,6 +53,35 @@
 		enable-active-high;
 		pinctrl-0 = <&lcd_bias_en>;
 		pinctrl-names = "default";
+	};
+
+	wcn3988-pmu {
+		compatible = "qcom,wcn3988-pmu";
+
+		vddio-supply = <&pm8150_s4>;
+		vddxo-supply = <&pm8150_l12>;
+		vddrf-supply = <&pm8150_l8>;
+		vddch0-supply = <&vreg_wcn_3p3>;
+
+		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+
+		regulators {
+			vreg_pmu_io: ldo0 {
+				regulator-name = "vreg_pmu_io";
+			};
+
+			vreg_pmu_xo: ldo1 {
+				regulator-name = "vreg_pmu_xo";
+			};
+
+			vreg_pmu_rf: ldo2 {
+				regulator-name = "vreg_pmu_rf";
+			};
+
+			vreg_pmu_ch0: ldo3 {
+				regulator-name = "vreg_pmu_ch0";
+			};
+		};
 	};
 };
 
@@ -177,10 +206,10 @@
 	status = "okay";
 
 	bluetooth {
-		vddio-supply = <&pm8150_s4>;
-		vddxo-supply = <&pm8150_l12>;
-		vddrf-supply = <&pm8150_l8>;
-		vddch0-supply = <&vreg_bt_3p3_dummy>;
+		vddio-supply = <&vreg_pmu_io>;
+		vddxo-supply = <&vreg_pmu_xo>;
+		vddrf-supply = <&vreg_pmu_rf>;
+		vddch0-supply = <&vreg_pmu_ch0>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -2902,14 +2902,6 @@
 				pinctrl-names = "default";
 
 				status = "disabled";
-
-				bluetooth {
-					compatible = "qcom,wcn3988-bt";
-
-					enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
-					max-speed = <3200000>;
-				};
-
 			};
 
 			i2c9: i2c@4aa4000 {


### PR DESCRIPTION
incremental PR building on #1132 and #1153, this PR adds wcn3988-pmu node with supply regulators and bt-enable-gpios to shikra EVK board DTS files. Update the BT node supply references to use PMU-managed LDOs (vreg_pmu_io/xo/rf/ch0) instead of direct PMIC regulators, and move BT node to the board-specific shikra-evk.dtsi.