### PR TITLE
PENDING: arm64: dts: qcom: glymur-crd: Add FocalTech FT3D81 touchscre…

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
@@ -658,17 +658,15 @@
 	status = "okay";
 
 	touchscreen@38 {
-		compatible = "hid-over-i2c";
+		compatible = "focaltech,ft8112";
 		reg = <0x38>;
 
-		hid-descr-addr = <0x1>;
 		interrupts-extended = <&tlmm 51 IRQ_TYPE_LEVEL_LOW>;
 
-		vdd-supply = <&vreg_misc_3p3>;
-		vddl-supply = <&vreg_l15b_e0_1p8>;
+		vcc33-supply = <&vreg_misc_3p3>;
+		vccio-supply = <&vreg_l15b_e0_1p8>;
 
 		reset-gpios = <&tlmm 48 GPIO_ACTIVE_LOW>;
-		post-power-on-delay-ms = <100>;
 
 		pinctrl-0 = <&ts0_default>;
 		pinctrl-names = "default";


### PR DESCRIPTION
…en support

The Glymur CRD board includes a FocalTech FT3D81 touchscreen connected to I2C bus.FT3D81 driver is compatible to ft112.