### PR TITLE
arm64: dts: qcom: shikra-iqs-evk: Add pinctrl for DLC0697 DSI panel

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -169,6 +169,29 @@
 	status = "okay";
 };
 
+&tlmm {
+	panel_rst_n: panel-rst-n-state {
+		pins = "gpio3";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	panel_rst_n_suspend: panel-rst-n-suspend-state {
+		pins = "gpio3";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	panel_te_pin: panel-te-pin-state {
+		pins = "gpio86";
+		function = "mdp_vsync_p";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+};
+
 &uart0 {
 	status = "okay";
 };


### PR DESCRIPTION
Incremental PR building on #1230. This PR adds the missing TLMM pinctrl nodes for the DLC0697 DSI panel (Reset and TE pins) on the Shikra platform.