### PR TITLE
ASoC: Add Shikra audio support

### DIFF
--- a/Documentation/devicetree/bindings/sound/qcom,lpass-rx-macro.yaml
+++ b/Documentation/devicetree/bindings/sound/qcom,lpass-rx-macro.yaml
@@ -19,6 +19,7 @@ properties:
           - qcom,sm8450-lpass-rx-macro
           - qcom,sm8550-lpass-rx-macro
           - qcom,sc8280xp-lpass-rx-macro
+          - qcom,shikra-lpass-rx-macro
       - items:
           - enum:
               - qcom,kaanapali-lpass-rx-macro

--- a/Documentation/devicetree/bindings/sound/qcom,lpass-va-macro.yaml
+++ b/Documentation/devicetree/bindings/sound/qcom,lpass-va-macro.yaml
@@ -19,6 +19,7 @@ properties:
           - qcom,sm8450-lpass-va-macro
           - qcom,sm8550-lpass-va-macro
           - qcom,sc8280xp-lpass-va-macro
+          - qcom,shikra-lpass-va-macro
       - items:
           - enum:
               - qcom,glymur-lpass-va-macro

--- a/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
+++ b/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
@@ -45,6 +45,7 @@ properties:
           - qcom,sc7180-qdsp6-sndcard
           - qcom,sc8280xp-sndcard
           - qcom,sdm845-sndcard
+          - qcom,shikra-sndcard
           - qcom,sm8250-sndcard
           - qcom,sm8450-sndcard
           - qcom,x1e80100-sndcard

--- a/Documentation/devicetree/bindings/soundwire/qcom,soundwire.yaml
+++ b/Documentation/devicetree/bindings/soundwire/qcom,soundwire.yaml
@@ -215,6 +215,12 @@ properties:
           maximum: 4
         - const: 0xff
 
+  qcom,swr-master-ee-val:
+    $ref: /schemas/types.yaml#/definitions/uint8-array
+    description:
+      Execution-environment value used to route SoundWire master
+      interrupts to CPU0 or CPU1.
+
   label:
     maxItems: 1
 

--- a/drivers/soundwire/qcom.c
+++ b/drivers/soundwire/qcom.c
@@ -26,6 +26,7 @@
 #define SWRM_COMP_STATUS					0x014
 #define SWRM_LINK_MANAGER_EE					0x018
 #define SWRM_EE_CPU						1
+#define SWRM_MAX_EE						1
 #define SWRM_FRM_GEN_ENABLED					BIT(0)
 #define SWRM_VERSION_1_3_0					0x01030000
 #define SWRM_VERSION_1_5_1					0x01050001
@@ -118,6 +119,7 @@
 #define SWRM_V2_0_CLK_CTRL					0x5060
 #define SWRM_V2_0_CLK_CTRL_CLK_START				BIT(0)
 #define SWRM_V2_0_LINK_STATUS					0x5064
+#define SWRM_V2_REG_EE_STRIDE					0x1000
 
 #define SWRM_DP_PORT_CTRL_EN_CHAN_SHFT				0x18
 #define SWRM_DP_PORT_CTRL_OFFSET2_SHFT				0x10
@@ -202,6 +204,7 @@ struct qcom_swrm_ctrl {
 	struct mutex port_lock;
 	struct clk *hclk;
 	int irq;
+	u32 ee;
 	unsigned int version;
 	int wake_irq;
 	int num_din_ports;
@@ -222,6 +225,7 @@ struct qcom_swrm_ctrl {
 	u32 slave_status;
 	u32 wr_fifo_depth;
 	bool clock_stop_not_supported;
+	unsigned int reg_layout_local[SWRM_OFFSET_DP_SAMPLECTRL2_BANK + 1];
 };
 
 struct qcom_swrm_data {
@@ -327,6 +331,36 @@ static const struct qcom_swrm_data swrm_v3_0_data = {
 	.reg_layout = swrm_v3_0_reg_layout,
 };
 #define to_qcom_sdw(b)	container_of(b, struct qcom_swrm_ctrl, bus)
+
+static void qcom_swrm_set_ee_register_layout(struct qcom_swrm_ctrl *ctrl,
+					     const struct qcom_swrm_data *data)
+{
+	int ee_offset;
+
+	memcpy(ctrl->reg_layout_local, data->reg_layout,
+	       sizeof(ctrl->reg_layout_local));
+	ctrl->reg_layout = ctrl->reg_layout_local;
+
+	if (ctrl->version < SWRM_VERSION_2_0_0)
+		return;
+
+	/*
+	 * Current register constants map EE1. For EE0, use the EE register
+	 * window stride to access status/IRQ/FIFO registers.
+	 */
+	ee_offset = ((int)ctrl->ee - SWRM_EE_CPU) * SWRM_V2_REG_EE_STRIDE;
+	if (!ee_offset)
+		return;
+
+	ctrl->reg_layout_local[SWRM_REG_FRAME_GEN_ENABLED] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_INTERRUPT_STATUS] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_INTERRUPT_CLEAR] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_INTERRUPT_CPU_EN] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_CMD_FIFO_WR_CMD] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_CMD_FIFO_RD_CMD] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_CMD_FIFO_STATUS] += ee_offset;
+	ctrl->reg_layout_local[SWRM_REG_CMD_FIFO_RD_FIFO_ADDR] += ee_offset;
+}
 
 static int qcom_swrm_ahb_reg_read(struct qcom_swrm_ctrl *ctrl, int reg,
 				  u32 *val)
@@ -904,12 +938,13 @@ static int qcom_swrm_init(struct qcom_swrm_ctrl *ctrl)
 	ctrl->reg_write(ctrl, SWRM_MCP_CFG_ADDR, val);
 
 	if (ctrl->version == SWRM_VERSION_1_7_0) {
-		ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, SWRM_EE_CPU);
+		ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, ctrl->ee);
 		ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL,
-				SWRM_MCP_BUS_CLK_START << SWRM_EE_CPU);
+				SWRM_MCP_BUS_CLK_START << ctrl->ee);
 	} else if (ctrl->version >= SWRM_VERSION_2_0_0) {
-		ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, SWRM_EE_CPU);
-		ctrl->reg_write(ctrl, SWRM_V2_0_CLK_CTRL,
+		ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, ctrl->ee);
+		ctrl->reg_write(ctrl, SWRM_V2_0_CLK_CTRL +
+				((int)ctrl->ee - SWRM_EE_CPU) * SWRM_V2_REG_EE_STRIDE,
 				SWRM_V2_0_CLK_CTRL_CLK_START);
 	} else {
 		ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL, SWRM_MCP_BUS_CLK_START);
@@ -935,11 +970,9 @@ static int qcom_swrm_init(struct qcom_swrm_ctrl *ctrl)
 	ctrl->reg_write(ctrl, ctrl->reg_layout[SWRM_REG_INTERRUPT_CLEAR],
 			0xFFFFFFFF);
 
-	/* enable CPU IRQs */
-	if (ctrl->mmio) {
-		ctrl->reg_write(ctrl, ctrl->reg_layout[SWRM_REG_INTERRUPT_CPU_EN],
-				SWRM_INTERRUPT_STATUS_RMSK);
-	}
+	/* enable CPU IRQs for the selected EE window */
+	ctrl->reg_write(ctrl, ctrl->reg_layout[SWRM_REG_INTERRUPT_CPU_EN],
+			SWRM_INTERRUPT_STATUS_RMSK);
 
 	/* Set IRQ to PULSE */
 	ctrl->reg_write(ctrl, SWRM_COMP_CFG_ADDR,
@@ -1545,7 +1578,22 @@ static int qcom_swrm_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	data = of_device_get_match_data(dev);
+	ctrl->ee = SWRM_EE_CPU;
+	ret = of_property_read_u32(dev->of_node, "qcom,swr-master-ee-val", &ctrl->ee);
+	if (ret)
+		ret = of_property_read_u32(dev->of_node, "qcom,ee", &ctrl->ee);
+	if (ret)
+		ctrl->ee = SWRM_EE_CPU;
+	if (ctrl->ee > SWRM_MAX_EE) {
+		dev_warn(dev, "invalid SoundWire EE %u, using EE%u\n",
+			 ctrl->ee, SWRM_EE_CPU);
+		ctrl->ee = SWRM_EE_CPU;
+	}
 	ctrl->max_reg = data->max_reg;
+	/*
+	 * Defer EE register window selection until HW version is known.
+	 * For v2.0+ the IRQ/FIFO window is EE-banked.
+	 */
 	ctrl->reg_layout = data->reg_layout;
 	ctrl->rows_index = sdw_find_row_index(data->default_rows);
 	ctrl->cols_index = sdw_find_col_index(data->default_cols);
@@ -1623,6 +1671,7 @@ static int qcom_swrm_probe(struct platform_device *pdev)
 	prop->default_row = data->default_rows;
 
 	ctrl->reg_read(ctrl, SWRM_COMP_HW_VERSION, &ctrl->version);
+	qcom_swrm_set_ee_register_layout(ctrl, data);
 
 	ret = devm_request_threaded_irq(dev, ctrl->irq, NULL,
 					qcom_swrm_irq_handler,
@@ -1724,24 +1773,26 @@ static int __maybe_unused swrm_runtime_resume(struct device *dev)
 		if (!swrm_wait_for_frame_gen_enabled(ctrl))
 			dev_err(ctrl->dev, "link failed to connect\n");
 
-		/* wait for hw enumeration to complete */
-		wait_for_completion_timeout(&ctrl->enumeration,
-					    msecs_to_jiffies(TIMEOUT_MS));
-		qcom_swrm_get_device_status(ctrl);
-		sdw_handle_slave_status(&ctrl->bus, ctrl->status);
-	} else {
-		reset_control_reset(ctrl->audio_cgcr);
-
-		if (ctrl->version == SWRM_VERSION_1_7_0) {
-			ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, SWRM_EE_CPU);
-			ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL,
-					SWRM_MCP_BUS_CLK_START << SWRM_EE_CPU);
-		} else if (ctrl->version >= SWRM_VERSION_2_0_0) {
-			ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, SWRM_EE_CPU);
-			ctrl->reg_write(ctrl, SWRM_V2_0_CLK_CTRL,
-					SWRM_V2_0_CLK_CTRL_CLK_START);
+			/* wait for hw enumeration to complete */
+			wait_for_completion_timeout(&ctrl->enumeration,
+						    msecs_to_jiffies(TIMEOUT_MS));
+			qcom_swrm_get_device_status(ctrl);
+			sdw_handle_slave_status(&ctrl->bus, ctrl->status);
 		} else {
-			ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL, SWRM_MCP_BUS_CLK_START);
+			reset_control_reset(ctrl->audio_cgcr);
+
+			if (ctrl->version == SWRM_VERSION_1_7_0) {
+				ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, ctrl->ee);
+				ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL,
+						SWRM_MCP_BUS_CLK_START << ctrl->ee);
+			} else if (ctrl->version >= SWRM_VERSION_2_0_0) {
+				ctrl->reg_write(ctrl, SWRM_LINK_MANAGER_EE, ctrl->ee);
+				ctrl->reg_write(ctrl, SWRM_V2_0_CLK_CTRL +
+						((int)ctrl->ee - SWRM_EE_CPU) *
+						SWRM_V2_REG_EE_STRIDE,
+						SWRM_V2_0_CLK_CTRL_CLK_START);
+			} else {
+				ctrl->reg_write(ctrl, SWRM_MCP_BUS_CTRL, SWRM_MCP_BUS_CLK_START);
 		}
 		ctrl->reg_write(ctrl, ctrl->reg_layout[SWRM_REG_INTERRUPT_CLEAR],
 			SWRM_INTERRUPT_STATUS_MASTER_CLASH_DET);

--- a/include/dt-bindings/sound/qcom,lpass.h
+++ b/include/dt-bindings/sound/qcom,lpass.h
@@ -41,6 +41,8 @@
 #define LPASS_CDC_DMA_VA_TX7 32
 #define LPASS_CDC_DMA_VA_TX8 33
 
+#define MI2S_SENARY 34
+
 #define LPASS_MCLK0	0
 
 #endif /* __DT_QCOM_LPASS_H */

--- a/sound/soc/codecs/lpass-macro-common.h
+++ b/sound/soc/codecs/lpass-macro-common.h
@@ -10,6 +10,8 @@
 #define LPASS_MACRO_FLAG_HAS_NPL_CLOCK		BIT(0)
 /* The soundwire block should be internally reset at probe */
 #define LPASS_MACRO_FLAG_RESET_SWR		BIT(1)
+/* FS counter control bit[7] must be toggled (Shikra / v4.0) */
+#define LPASS_MACRO_FLAG_BYPASS_FS_CONTROL	BIT(2)
 
 enum lpass_version {
 	LPASS_VER_9_0_0,
@@ -30,6 +32,7 @@ enum lpass_codec_version {
 	LPASS_CODEC_VERSION_2_7,
 	LPASS_CODEC_VERSION_2_8,
 	LPASS_CODEC_VERSION_2_9,
+	LPASS_CODEC_VERSION_4_0,
 };
 
 struct lpass_macro {
@@ -68,6 +71,8 @@ static inline const char *lpass_macro_get_codec_version_string(int version)
 		return "v2.7";
 	case LPASS_CODEC_VERSION_2_8:
 		return "v2.8";
+	case LPASS_CODEC_VERSION_4_0:
+		return "v4.0";
 	default:
 		break;
 	}

--- a/sound/soc/codecs/lpass-rx-macro.c
+++ b/sound/soc/codecs/lpass-rx-macro.c
@@ -646,6 +646,7 @@ struct rx_macro {
 	int clsh_users;
 	int rx_mclk_cnt;
 	enum lpass_codec_version codec_version;
+	bool bypass_fs_control;
 	int rxn_reg_stride;
 	int rxn_reg_stride2;
 	bool is_ear_mode_on;
@@ -1612,6 +1613,7 @@ static bool rx_is_rw_register(struct device *dev, unsigned int reg)
 	case LPASS_CODEC_VERSION_2_6:
 	case LPASS_CODEC_VERSION_2_7:
 	case LPASS_CODEC_VERSION_2_8:
+	case LPASS_CODEC_VERSION_4_0:
 		return rx_2_5_is_rw_register(dev, reg);
 	default:
 		break;
@@ -2043,6 +2045,11 @@ static void rx_macro_mclk_enable(struct rx_macro *rx, bool mclk_enable)
 					   CDC_RX_CLK_MCLK2_ENABLE);
 			regmap_update_bits(regmap, CDC_RX_CLK_RST_CTRL_FS_CNT_CONTROL,
 					   CDC_RX_FS_MCLK_CNT_CLR_MASK, 0x00);
+
+			if (rx->bypass_fs_control)
+				regmap_update_bits(regmap,
+						   CDC_RX_CLK_RST_CTRL_FS_CNT_CONTROL,
+						   0x80, 0x80);
 			regmap_update_bits(regmap, CDC_RX_CLK_RST_CTRL_FS_CNT_CONTROL,
 					   CDC_RX_FS_MCLK_CNT_EN_MASK,
 					   CDC_RX_FS_MCLK_CNT_ENABLE);
@@ -3648,6 +3655,7 @@ static int rx_macro_component_probe(struct snd_soc_component *component)
 	case LPASS_CODEC_VERSION_2_6:
 	case LPASS_CODEC_VERSION_2_7:
 	case LPASS_CODEC_VERSION_2_8:
+	case LPASS_CODEC_VERSION_4_0:
 		controls = rx_macro_2_5_snd_controls;
 		num_controls = ARRAY_SIZE(rx_macro_2_5_snd_controls);
 		widgets = rx_macro_2_5_dapm_widgets;
@@ -3809,6 +3817,7 @@ static int rx_macro_probe(struct platform_device *pdev)
 		return PTR_ERR(base);
 
 	rx->codec_version = lpass_macro_get_codec_version();
+	rx->bypass_fs_control = !!(flags & LPASS_MACRO_FLAG_BYPASS_FS_CONTROL);
 	struct reg_default *reg_defaults __free(kfree) = NULL;
 
 	switch (rx->codec_version) {
@@ -3831,6 +3840,7 @@ static int rx_macro_probe(struct platform_device *pdev)
 	case LPASS_CODEC_VERSION_2_6:
 	case LPASS_CODEC_VERSION_2_7:
 	case LPASS_CODEC_VERSION_2_8:
+	case LPASS_CODEC_VERSION_4_0:
 		rx->rxn_reg_stride = 0xc0;
 		rx->rxn_reg_stride2 = 0x0;
 		def_count = ARRAY_SIZE(rx_defaults) + ARRAY_SIZE(rx_2_5_defaults);
@@ -3961,6 +3971,10 @@ static const struct of_device_id rx_macro_dt_match[] = {
 	}, {
 		.compatible = "qcom,sc8280xp-lpass-rx-macro",
 		.data = (void *)LPASS_MACRO_FLAG_HAS_NPL_CLOCK,
+	}, {
+		.compatible = "qcom,shikra-lpass-rx-macro",
+		.data = (void *)(LPASS_MACRO_FLAG_HAS_NPL_CLOCK |
+				LPASS_MACRO_FLAG_BYPASS_FS_CONTROL),
 	},
 	{ }
 };

--- a/sound/soc/codecs/lpass-va-macro.c
+++ b/sound/soc/codecs/lpass-va-macro.c
@@ -81,6 +81,14 @@
 #define CDC_VA_SWR_MIC_CLK_SEL_0_1_MASK		(0xEE)
 #define CDC_VA_SWR_MIC_CLK_SEL_0_1_DIV1		(0xCC)
 #define CDC_VA_TOP_CSR_SWR_CTRL			(0x00DC)
+
+#define CDC_VA_TOP_CSR_SWR_GPIN_CH0			(0x00E0)
+#define CDC_VA_TOP_CSR_SWR_GPIN_CH1			(0x00E4)
+#define CDC_VA_TOP_CSR_TOP_CFG2				(0x00EC)
+#define CDC_VA_TOP_CSR_TOP_CFG3				(0x00F0)
+#define CDC_VA_TOP_CSR_SWR_GPOUT_CH0		(0x00F8)
+#define CDC_VA_TOP_CSR_SWR_GPOUT_CH1		(0x00FC)
+
 #define CDC_VA_INP_MUX_ADC_MUX0_CFG0		(0x0100)
 #define CDC_VA_INP_MUX_ADC_MUX0_CFG1		(0x0104)
 #define CDC_VA_INP_MUX_ADC_MUX1_CFG0		(0x0108)
@@ -89,6 +97,40 @@
 #define CDC_VA_INP_MUX_ADC_MUX2_CFG1		(0x0114)
 #define CDC_VA_INP_MUX_ADC_MUX3_CFG0		(0x0118)
 #define CDC_VA_INP_MUX_ADC_MUX3_CFG1		(0x011C)
+
+/* ADC MUX4-7 CFG0/1 - Bolero V4 extended decimator mux (up to 8 DMICs) */
+#define CDC_VA_INP_MUX_ADC_MUX4_CFG0		(0x0120)
+#define CDC_VA_INP_MUX_ADC_MUX4_CFG1		(0x0124)
+#define CDC_VA_INP_MUX_ADC_MUX5_CFG0		(0x0128)
+#define CDC_VA_INP_MUX_ADC_MUX5_CFG1		(0x012C)
+#define CDC_VA_INP_MUX_ADC_MUX6_CFG0		(0x0130)
+#define CDC_VA_INP_MUX_ADC_MUX6_CFG1		(0x0134)
+#define CDC_VA_INP_MUX_ADC_MUX7_CFG0		(0x0138)
+#define CDC_VA_INP_MUX_ADC_MUX7_CFG1		(0x013C)
+
+/* ADC MUXx CFG2 - Bolero V4 CFG2 extension for all 8 MUXes */
+#define CDC_VA_INP_MUX_ADC_MUX0_CFG2		(0x0140)
+#define CDC_VA_INP_MUX_ADC_MUX1_CFG2		(0x0144)
+#define CDC_VA_INP_MUX_ADC_MUX2_CFG2		(0x0148)
+#define CDC_VA_INP_MUX_ADC_MUX3_CFG2		(0x014C)
+#define CDC_VA_INP_MUX_ADC_MUX4_CFG2		(0x0150)
+#define CDC_VA_INP_MUX_ADC_MUX5_CFG2		(0x0154)
+#define CDC_VA_INP_MUX_ADC_MUX6_CFG2		(0x0158)
+#define CDC_VA_INP_MUX_ADC_MUX7_CFG2		(0x015C)
+
+/* INTR_CTRL registers - SWR interrupt controller (VA macro owns SWR0 on QCM2290) */
+#define CDC_VA_MACRO_INTR_CTRL_CFG		(0x0340)
+#define CDC_VA_MACRO_INTR_CTRL_CLR_COMMIT	(0x0344)
+#define CDC_VA_MACRO_INTR_CTRL_PIN1_MASK0	(0x0360)
+#define CDC_VA_MACRO_INTR_CTRL_PIN1_STATUS0	(0x0368)
+#define CDC_VA_MACRO_INTR_CTRL_PIN1_CLEAR0	(0x0370)
+#define CDC_VA_MACRO_INTR_CTRL_PIN2_MASK0	(0x0380)
+#define CDC_VA_MACRO_INTR_CTRL_PIN2_STATUS0	(0x0388)
+#define CDC_VA_MACRO_INTR_CTRL_PIN2_CLEAR0	(0x0390)
+#define CDC_VA_MACRO_INTR_CTRL_LEVEL0		(0x03C0)
+#define CDC_VA_MACRO_INTR_CTRL_BYPASS0		(0x03C8)
+#define CDC_VA_MACRO_INTR_CTRL_SET0		(0x03D0)
+
 #define CDC_VA_TX0_TX_PATH_CTL			(0x0400)
 #define CDC_VA_TX_PATH_CLK_EN_MASK		BIT(5)
 #define CDC_VA_TX_PATH_CLK_EN			BIT(5)
@@ -118,6 +160,9 @@
 #define CDC_VA_TX0_TX_PATH_SEC5			(0x0424)
 #define CDC_VA_TX0_TX_PATH_SEC6			(0x0428)
 #define CDC_VA_TX0_TX_PATH_SEC7			(0x042C)
+
+#define CDC_VA_TX0_TX_PATH_CFG2			(0x0430)
+
 #define CDC_VA_TX1_TX_PATH_CTL			(0x0480)
 #define CDC_VA_TX1_TX_PATH_CFG0			(0x0484)
 #define CDC_VA_TX1_TX_PATH_CFG1			(0x0488)
@@ -129,6 +174,9 @@
 #define CDC_VA_TX1_TX_PATH_SEC4			(0x04A0)
 #define CDC_VA_TX1_TX_PATH_SEC5			(0x04A4)
 #define CDC_VA_TX1_TX_PATH_SEC6			(0x04A8)
+
+#define CDC_VA_TX1_TX_PATH_CFG2			(0x04B0)
+
 #define CDC_VA_TX2_TX_PATH_CTL			(0x0500)
 #define CDC_VA_TX2_TX_PATH_CFG0			(0x0504)
 #define CDC_VA_TX2_TX_PATH_CFG1			(0x0508)
@@ -140,6 +188,9 @@
 #define CDC_VA_TX2_TX_PATH_SEC4			(0x0520)
 #define CDC_VA_TX2_TX_PATH_SEC5			(0x0524)
 #define CDC_VA_TX2_TX_PATH_SEC6			(0x0528)
+
+#define CDC_VA_TX2_TX_PATH_CFG2			(0x0530)
+
 #define CDC_VA_TX3_TX_PATH_CTL			(0x0580)
 #define CDC_VA_TX3_TX_PATH_CFG0			(0x0584)
 #define CDC_VA_TX_PATH_ADC_DMIC_SEL_MASK	BIT(7)
@@ -155,7 +206,66 @@
 #define CDC_VA_TX3_TX_PATH_SEC5			(0x05A4)
 #define CDC_VA_TX3_TX_PATH_SEC6			(0x05A8)
 
-#define VA_MAX_OFFSET				(0x07A8)
+#define CDC_VA_TX3_TX_PATH_CFG2			(0x05B0)
+
+#define CDC_VA_CDC_ADPT0_ADPT_CTRL			(0x0800)
+#define CDC_VA_CDC_ADPT0_ADPT_GAIN_0		(0x0804)
+#define CDC_VA_CDC_ADPT0_ADPT_GAIN_1		(0x0808)
+#define CDC_VA_CDC_ADPT0_DH_FSM_CTRL		(0x080C)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_0	(0x0810)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_1	(0x0814)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_2	(0x0818)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_3	(0x081C)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_4	(0x0820)
+#define CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_5	(0x0824)
+
+#define CDC_VA_CDC_ADPT1_ADPT_CTRL			(0x0880)
+#define CDC_VA_CDC_ADPT1_ADPT_GAIN_0		(0x0884)
+#define CDC_VA_CDC_ADPT1_ADPT_GAIN_1		(0x0888)
+#define CDC_VA_CDC_ADPT1_DH_FSM_CTRL		(0x088C)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_0	(0x0890)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_1	(0x0894)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_2	(0x0898)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_3	(0x089C)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_4	(0x08A0)
+#define CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_5	(0x08A4)
+#define CDC_VA_CDC_ADPT1_DBG_CTRL				(0x08B0)
+#define CDC_VA_CDC_ADPT1_DBG_PDM_RATE_CTRL_0	(0x08B2)
+#define CDC_VA_CDC_ADPT1_DBG_PDM_RATE_CTRL_1	(0x08B4)
+#define CDC_VA_CDC_ADPT1_SPARE0					(0x08B8)
+
+#define CDC_VA_CDC_ADPT2_ADPT_CTRL			(0x0900)
+#define CDC_VA_CDC_ADPT2_ADPT_GAIN_0		(0x0904)
+#define CDC_VA_CDC_ADPT2_ADPT_GAIN_1		(0x0908)
+#define CDC_VA_CDC_ADPT2_DH_FSM_CTRL		(0x090C)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_0	(0x0910)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_1	(0x0914)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_2	(0x0918)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_3	(0x091C)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_4	(0x0920)
+#define CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_5	(0x0924)
+
+#define CDC_VA_CDC_ADPT3_ADPT_CTRL			(0x0980)
+#define CDC_VA_CDC_ADPT3_ADPT_GAIN_0		(0x0984)
+#define CDC_VA_CDC_ADPT3_ADPT_GAIN_1		(0x0988)
+#define CDC_VA_CDC_ADPT3_DH_FSM_CTRL		(0x098C)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_0	(0x0990)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_1	(0x0994)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_2	(0x0998)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_3	(0x099C)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_4	(0x09A0)
+#define CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_5	(0x09A4)
+
+/* VA ALT TOP registers - Bolero V4 alternate top config */
+#define CDC_VA_ALT_TOP_VA_CFG0			0x1000
+#define CDC_VA_ALT_TOP_RX_CFG0			0x1040
+#define CDC_VA_ALT_TOP_WSA1_CFG0		0x1080
+#define CDC_VA_ALT_TOP_WSA2_CFG0		0x10C0
+#define CDC_VA_ALT_TOP_WSA3_CFG0		0x1100
+#define CDC_VA_ALT_TOP_WSA4_CFG0		0x1140
+
+#define VA_MAX_OFFSET				(0x1240)
+#define VA_MAX_OFFSET_PRE_4_0			(0x07A8)
 
 #define VA_MACRO_NUM_DECIMATORS 4
 #define VA_MACRO_RATES (SNDRV_PCM_RATE_8000 | SNDRV_PCM_RATE_16000 |\
@@ -209,6 +319,8 @@ struct va_macro {
 	u16 dmic_clk_div;
 	bool has_swr_master;
 	bool has_npl_clk;
+	bool bypass_fs_control;
+	enum lpass_codec_version codec_version;
 
 	int dec_mode[VA_MACRO_NUM_DECIMATORS];
 	struct regmap *regmap;
@@ -235,6 +347,7 @@ struct va_macro {
 struct va_macro_data {
 	bool has_swr_master;
 	bool has_npl_clk;
+	bool bypass_fs_control;
 	int version;
 };
 
@@ -247,6 +360,13 @@ static const struct va_macro_data sm8250_va_data = {
 static const struct va_macro_data sm8450_va_data = {
 	.has_swr_master = true,
 	.has_npl_clk = true,
+};
+
+static const struct va_macro_data shikra_va_data = {
+	.has_swr_master = true,
+	.has_npl_clk = true,
+	.bypass_fs_control = true,
+	.version = LPASS_CODEC_VERSION_4_0,
 };
 
 static const struct va_macro_data sm8550_va_data = {
@@ -266,7 +386,23 @@ static bool va_is_volatile_register(struct device *dev, unsigned int reg)
 	case CDC_VA_TOP_CSR_DMIC2_CTL:
 	case CDC_VA_TOP_CSR_DMIC3_CTL:
 		return true;
+	default:
+		break;
 	}
+
+	if (lpass_macro_get_codec_version() == LPASS_CODEC_VERSION_4_0) {
+		switch (reg) {
+		case CDC_VA_MACRO_INTR_CTRL_PIN1_STATUS0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN1_CLEAR0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN2_STATUS0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN2_CLEAR0:
+		case CDC_VA_MACRO_INTR_CTRL_CLR_COMMIT:
+			return true;
+		default:
+			break;
+		}
+	}
+
 	return false;
 }
 
@@ -304,6 +440,7 @@ static const struct reg_default va_defaults[] = {
 	{ CDC_VA_INP_MUX_ADC_MUX2_CFG1, 0x00},
 	{ CDC_VA_INP_MUX_ADC_MUX3_CFG0, 0x00},
 	{ CDC_VA_INP_MUX_ADC_MUX3_CFG1, 0x00},
+
 	{ CDC_VA_TX0_TX_PATH_CTL, 0x04},
 	{ CDC_VA_TX0_TX_PATH_CFG0, 0x10},
 	{ CDC_VA_TX0_TX_PATH_CFG1, 0x0B},
@@ -349,6 +486,101 @@ static const struct reg_default va_defaults[] = {
 	{ CDC_VA_TX3_TX_PATH_SEC4, 0x20},
 	{ CDC_VA_TX3_TX_PATH_SEC5, 0x00},
 	{ CDC_VA_TX3_TX_PATH_SEC6, 0x00},
+};
+
+/* Register defaults specific to LPASS codec v4.0 (Shikra) */
+static const struct reg_default va_4_0_defaults[] = {
+	/* ADC MUX4-7 CFG0/1 - 8-DMIC support */
+	{ CDC_VA_INP_MUX_ADC_MUX4_CFG0,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX4_CFG1,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX5_CFG0,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX5_CFG1,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX6_CFG0,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX6_CFG1,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX7_CFG0,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX7_CFG1,		0x00 },
+
+	/* ADC MUXx CFG2 extension */
+	{ CDC_VA_INP_MUX_ADC_MUX0_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX1_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX2_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX3_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX4_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX5_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX6_CFG2,		0x00 },
+	{ CDC_VA_INP_MUX_ADC_MUX7_CFG2,		0x00 },
+
+	/* INTR_CTRL: SWR interrupt masking registers */
+	{ CDC_VA_MACRO_INTR_CTRL_CFG,			0x00 },
+	{ CDC_VA_MACRO_INTR_CTRL_PIN1_MASK0,		0xFF },
+	{ CDC_VA_MACRO_INTR_CTRL_PIN1_STATUS0,		0x00 },
+	{ CDC_VA_MACRO_INTR_CTRL_PIN2_MASK0,		0xFF },
+	{ CDC_VA_MACRO_INTR_CTRL_PIN2_STATUS0,		0x00 },
+	{ CDC_VA_MACRO_INTR_CTRL_LEVEL0,		0x00 },
+	{ CDC_VA_MACRO_INTR_CTRL_BYPASS0,		0x00 },
+	{ CDC_VA_MACRO_INTR_CTRL_SET0,			0x00 },
+
+	/* TX PATH CFG2 per decimator */
+	{ CDC_VA_TX0_TX_PATH_CFG2,			0x03 },
+	{ CDC_VA_TX1_TX_PATH_CFG2,			0x03 },
+	{ CDC_VA_TX2_TX_PATH_CFG2,			0x03 },
+	{ CDC_VA_TX3_TX_PATH_CFG2,			0x03 },
+
+	/* CDC ADPT0 - adaptive filter */
+	{ CDC_VA_CDC_ADPT0_ADPT_CTRL,			0x51 },
+	{ CDC_VA_CDC_ADPT0_ADPT_GAIN_0,			0x11 },
+	{ CDC_VA_CDC_ADPT0_ADPT_GAIN_1,			0x01 },
+	{ CDC_VA_CDC_ADPT0_DH_FSM_CTRL,			0x02 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_0,		0x77 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_1,		0x64 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_2,		0x00 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_3,		0x41 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_4,		0x04 },
+	{ CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_5,		0x01 },
+
+	/* CDC ADPT1 */
+	{ CDC_VA_CDC_ADPT1_ADPT_CTRL,			0x51 },
+	{ CDC_VA_CDC_ADPT1_ADPT_GAIN_0,			0x11 },
+	{ CDC_VA_CDC_ADPT1_ADPT_GAIN_1,			0x01 },
+	{ CDC_VA_CDC_ADPT1_DH_FSM_CTRL,			0x02 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_0,		0x77 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_1,		0x64 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_2,		0x00 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_3,		0x41 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_4,		0x04 },
+	{ CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_5,		0x01 },
+
+	/* CDC ADPT2 */
+	{ CDC_VA_CDC_ADPT2_ADPT_CTRL,			0x51 },
+	{ CDC_VA_CDC_ADPT2_ADPT_GAIN_0,			0x11 },
+	{ CDC_VA_CDC_ADPT2_ADPT_GAIN_1,			0x01 },
+	{ CDC_VA_CDC_ADPT2_DH_FSM_CTRL,			0x02 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_0,		0x77 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_1,		0x64 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_2,		0x00 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_3,		0x41 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_4,		0x04 },
+	{ CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_5,		0x01 },
+
+	/* CDC ADPT3 */
+	{ CDC_VA_CDC_ADPT3_ADPT_CTRL,			0x51 },
+	{ CDC_VA_CDC_ADPT3_ADPT_GAIN_0,			0x11 },
+	{ CDC_VA_CDC_ADPT3_ADPT_GAIN_1,			0x01 },
+	{ CDC_VA_CDC_ADPT3_DH_FSM_CTRL,			0x02 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_0,		0x77 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_1,		0x64 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_2,		0x00 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_3,		0x41 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_4,		0x04 },
+	{ CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_5,		0x01 },
+
+	/* VA ALT TOP */
+	{ CDC_VA_ALT_TOP_VA_CFG0,			0x00 },
+	{ CDC_VA_ALT_TOP_RX_CFG0,			0x00 },
+	{ CDC_VA_ALT_TOP_WSA1_CFG0,			0x00 },
+	{ CDC_VA_ALT_TOP_WSA2_CFG0,			0x00 },
+	{ CDC_VA_ALT_TOP_WSA3_CFG0,			0x00 },
+	{ CDC_VA_ALT_TOP_WSA4_CFG0,			0x00 },
 };
 
 static bool va_is_rw_register(struct device *dev, unsigned int reg)
@@ -425,6 +657,41 @@ static bool va_is_rw_register(struct device *dev, unsigned int reg)
 	case CDC_VA_TX3_TX_PATH_SEC5:
 	case CDC_VA_TX3_TX_PATH_SEC6:
 		return true;
+	default:
+		break;
+	}
+
+	if (lpass_macro_get_codec_version() == LPASS_CODEC_VERSION_4_0) {
+		switch (reg) {
+		case CDC_VA_MACRO_INTR_CTRL_CFG:
+		case CDC_VA_MACRO_INTR_CTRL_CLR_COMMIT:
+		case CDC_VA_MACRO_INTR_CTRL_PIN1_MASK0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN1_CLEAR0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN2_MASK0:
+		case CDC_VA_MACRO_INTR_CTRL_PIN2_CLEAR0:
+		case CDC_VA_MACRO_INTR_CTRL_LEVEL0:
+		case CDC_VA_MACRO_INTR_CTRL_BYPASS0:
+		case CDC_VA_MACRO_INTR_CTRL_SET0:
+		case CDC_VA_INP_MUX_ADC_MUX4_CFG0 ... CDC_VA_INP_MUX_ADC_MUX7_CFG1:
+		case CDC_VA_INP_MUX_ADC_MUX0_CFG2 ... CDC_VA_INP_MUX_ADC_MUX7_CFG2:
+		case CDC_VA_TX0_TX_PATH_CFG2:
+		case CDC_VA_TX1_TX_PATH_CFG2:
+		case CDC_VA_TX2_TX_PATH_CFG2:
+		case CDC_VA_TX3_TX_PATH_CFG2:
+		case CDC_VA_ALT_TOP_VA_CFG0:
+		case CDC_VA_ALT_TOP_RX_CFG0:
+		case CDC_VA_ALT_TOP_WSA1_CFG0:
+		case CDC_VA_ALT_TOP_WSA2_CFG0:
+		case CDC_VA_ALT_TOP_WSA3_CFG0:
+		case CDC_VA_ALT_TOP_WSA4_CFG0:
+		case CDC_VA_CDC_ADPT0_ADPT_CTRL ... CDC_VA_CDC_ADPT0_CUTOFF_FSM_CTRL_5:
+		case CDC_VA_CDC_ADPT1_ADPT_CTRL ... CDC_VA_CDC_ADPT1_CUTOFF_FSM_CTRL_5:
+		case CDC_VA_CDC_ADPT2_ADPT_CTRL ... CDC_VA_CDC_ADPT2_CUTOFF_FSM_CTRL_5:
+		case CDC_VA_CDC_ADPT3_ADPT_CTRL ... CDC_VA_CDC_ADPT3_CUTOFF_FSM_CTRL_5:
+			return true;
+		default:
+			break;
+		}
 	}
 
 	return false;
@@ -449,9 +716,6 @@ static const struct regmap_config va_regmap_config = {
 	.val_bits = 32,
 	.reg_stride = 4,
 	.cache_type = REGCACHE_FLAT,
-	.reg_defaults = va_defaults,
-	.num_reg_defaults = ARRAY_SIZE(va_defaults),
-	.max_register = VA_MAX_OFFSET,
 	.volatile_reg = va_is_volatile_register,
 	.readable_reg = va_is_readable_register,
 	.writeable_reg = va_is_rw_register,
@@ -469,6 +733,10 @@ static int va_clk_rsc_fs_gen_request(struct va_macro *va, bool enable)
 		regmap_update_bits(regmap, CDC_VA_CLK_RST_CTRL_FS_CNT_CONTROL,
 				   CDC_VA_FS_CONTROL_EN | CDC_VA_FS_COUNTER_CLR,
 				   CDC_VA_FS_CONTROL_EN | CDC_VA_FS_COUNTER_CLR);
+
+		if (va->bypass_fs_control)
+			regmap_update_bits(regmap, CDC_VA_CLK_RST_CTRL_FS_CNT_CONTROL,
+					   0x80, 0x80);
 		regmap_update_bits(regmap, CDC_VA_CLK_RST_CTRL_FS_CNT_CONTROL,
 				   CDC_VA_FS_CONTROL_EN | CDC_VA_FS_COUNTER_CLR,
 				   CDC_VA_FS_CONTROL_EN);
@@ -1386,10 +1654,23 @@ static int fsgen_gate_is_enabled(struct clk_hw *hw)
 	return  !!(val & CDC_VA_FS_BROADCAST_EN);
 }
 
+static unsigned long fsgen_recalc_rate(struct clk_hw *hw,
+				       unsigned long parent_rate)
+{
+	return parent_rate / 2;
+}
+
 static const struct clk_ops fsgen_gate_ops = {
 	.prepare = fsgen_gate_enable,
 	.unprepare = fsgen_gate_disable,
 	.is_enabled = fsgen_gate_is_enabled,
+};
+
+static const struct clk_ops fsgen_gate_ops_4_0 = {
+	.prepare = fsgen_gate_enable,
+	.unprepare = fsgen_gate_disable,
+	.is_enabled = fsgen_gate_is_enabled,
+	.recalc_rate = fsgen_recalc_rate,
 };
 
 static int va_macro_register_fsgen_output(struct va_macro *va)
@@ -1410,7 +1691,8 @@ static int va_macro_register_fsgen_output(struct va_macro *va)
 	of_property_read_string(np, "clock-output-names", &clk_name);
 
 	init.name = clk_name;
-	init.ops = &fsgen_gate_ops;
+	init.ops = (va->codec_version == LPASS_CODEC_VERSION_4_0)
+			? &fsgen_gate_ops_4_0 : &fsgen_gate_ops;
 	init.flags = 0;
 	init.parent_names = &parent_clk_name;
 	init.num_parents = 1;
@@ -1511,6 +1793,14 @@ static int va_macro_set_lpass_codec_version(struct va_macro *va)
 		default:
 			break;
 		}
+	} else if (maj == 4) {
+		switch (min) {
+		case 0:
+			version = LPASS_CODEC_VERSION_4_0;
+			break;
+		default:
+			break;
+		}
 	}
 
 	if (version == LPASS_CODEC_VERSION_UNKNOWN) {
@@ -1520,6 +1810,7 @@ static int va_macro_set_lpass_codec_version(struct va_macro *va)
 	}
 
 	lpass_macro_set_codec_version(version);
+	va->codec_version = version;
 
 	dev_dbg(va->dev, "LPASS Codec Version %s\n", lpass_macro_get_codec_version_string(version));
 
@@ -1576,17 +1867,60 @@ static int va_macro_probe(struct platform_device *pdev)
 		goto err;
 	}
 
-	va->regmap = devm_regmap_init_mmio(dev, base,  &va_regmap_config);
+	data = of_device_get_match_data(dev);
+	va->has_swr_master = data->has_swr_master;
+	va->has_npl_clk = data->has_npl_clk;
+	va->bypass_fs_control = data->bypass_fs_control;
+
+	/*
+	 * Use the version from match data if available; for platforms that
+	 * detect version from registers, clocks must be enabled first, so
+	 * the full detection is deferred to after clk_prepare_enable below.
+	 */
+	va->codec_version = data->version ? data->version : LPASS_CODEC_VERSION_UNKNOWN;
+
+	int def_count;
+	struct reg_default *reg_defaults_buf __free(kfree) = NULL;
+
+	if (va->codec_version == LPASS_CODEC_VERSION_4_0) {
+		def_count = ARRAY_SIZE(va_defaults) + ARRAY_SIZE(va_4_0_defaults);
+		reg_defaults_buf = kmalloc_objs(struct reg_default, def_count);
+		if (!reg_defaults_buf) {
+			ret = -ENOMEM;
+			goto err;
+		}
+		memcpy(&reg_defaults_buf[0], va_defaults, sizeof(va_defaults));
+		memcpy(&reg_defaults_buf[ARRAY_SIZE(va_defaults)],
+		       va_4_0_defaults, sizeof(va_4_0_defaults));
+	} else {
+		def_count = ARRAY_SIZE(va_defaults);
+		reg_defaults_buf = kmalloc_objs(struct reg_default, def_count);
+		if (!reg_defaults_buf) {
+			ret = -ENOMEM;
+			goto err;
+		}
+		memcpy(reg_defaults_buf, va_defaults, sizeof(va_defaults));
+	}
+
+	struct regmap_config *reg_config __free(kfree) =
+		kmemdup(&va_regmap_config, sizeof(va_regmap_config), GFP_KERNEL);
+	if (!reg_config) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
+	reg_config->reg_defaults = reg_defaults_buf;
+	reg_config->num_reg_defaults = def_count;
+	reg_config->max_register = (va->codec_version == LPASS_CODEC_VERSION_4_0)
+					? VA_MAX_OFFSET : VA_MAX_OFFSET_PRE_4_0;
+
+	va->regmap = devm_regmap_init_mmio(dev, base, reg_config);
 	if (IS_ERR(va->regmap)) {
-		ret = -EINVAL;
+		ret = PTR_ERR(va->regmap);
 		goto err;
 	}
 
 	dev_set_drvdata(dev, va);
-
-	data = of_device_get_match_data(dev);
-	va->has_swr_master = data->has_swr_master;
-	va->has_npl_clk = data->has_npl_clk;
 
 	/* mclk rate */
 	clk_set_rate(va->mclk, 2 * VA_MACRO_MCLK_FREQ);
@@ -1625,6 +1959,7 @@ static int va_macro_probe(struct platform_device *pdev)
 	 */
 	if (data->version) {
 		lpass_macro_set_codec_version(data->version);
+		va->codec_version = data->version;
 	} else {
 		/* read version from register */
 		ret = va_macro_set_lpass_codec_version(va);
@@ -1761,6 +2096,7 @@ static const struct of_device_id va_macro_dt_match[] = {
 	{ .compatible = "qcom,sm8450-lpass-va-macro", .data = &sm8450_va_data },
 	{ .compatible = "qcom,sm8550-lpass-va-macro", .data = &sm8550_va_data },
 	{ .compatible = "qcom,sc8280xp-lpass-va-macro", .data = &sm8450_va_data },
+	{ .compatible = "qcom,shikra-lpass-va-macro", .data = &shikra_va_data },
 	{}
 };
 MODULE_DEVICE_TABLE(of, va_macro_dt_match);

--- a/sound/soc/codecs/lpass-va-macro.c
+++ b/sound/soc/codecs/lpass-va-macro.c
@@ -310,6 +310,11 @@ enum {
 	VA_MACRO_CLK_DIV_16,
 };
 
+enum {
+	MSM_DMIC,
+	SWR_MIC,
+};
+
 #define VA_NUM_CLKS_MAX		3
 
 struct va_macro {
@@ -820,12 +825,30 @@ static int va_macro_put_dec_enum(struct snd_kcontrol *kcontrol,
 		return -EINVAL;
 	}
 
-	if (val != 0)
-		snd_soc_component_update_bits(component, mic_sel_reg,
-					      CDC_VA_TX_PATH_ADC_DMIC_SEL_MASK,
-					      CDC_VA_TX_PATH_ADC_DMIC_SEL_DMIC);
+	if (val != 0) {
+		if (strnstr(widget->name, "SMIC", strlen(widget->name)))
+			snd_soc_component_update_bits(component, mic_sel_reg,
+						      CDC_VA_TX_PATH_ADC_DMIC_SEL_MASK, 0);
+		else
+			snd_soc_component_update_bits(component, mic_sel_reg,
+						      CDC_VA_TX_PATH_ADC_DMIC_SEL_MASK,
+						      CDC_VA_TX_PATH_ADC_DMIC_SEL_DMIC);
+	}
 
 	return snd_soc_dapm_put_enum_double(kcontrol, ucontrol);
+}
+
+static bool is_amic_enabled(struct snd_soc_component *comp, int decimator)
+{
+	u16 adc_mux_reg = 0;
+	bool ret = false;
+
+	adc_mux_reg = CDC_VA_INP_MUX_ADC_MUX0_CFG1 +
+		      VA_MACRO_ADC_MUX_CFG_OFFSET * decimator;
+	if (snd_soc_component_read(comp, adc_mux_reg) & SWR_MIC)
+		return true;
+
+	return ret;
 }
 
 static int va_macro_tx_mixer_get(struct snd_kcontrol *kcontrol,
@@ -1012,6 +1035,8 @@ static int va_macro_enable_dec(struct snd_soc_dapm_widget *w,
 	u16 tx_vol_ctl_reg, dec_cfg_reg, hpf_gate_reg;
 	u16 tx_gain_ctl_reg;
 	u8 hpf_cut_off_freq;
+	u16 adc_mux0_reg = 0;
+	u16 adapt_ctrl = 0;
 
 	struct va_macro *va = snd_soc_component_get_drvdata(comp);
 
@@ -1025,6 +1050,10 @@ static int va_macro_enable_dec(struct snd_soc_dapm_widget *w,
 				VA_MACRO_TX_PATH_OFFSET * decimator;
 	tx_gain_ctl_reg = CDC_VA_TX0_TX_VOL_CTL +
 				VA_MACRO_TX_PATH_OFFSET * decimator;
+	adc_mux0_reg = CDC_VA_INP_MUX_ADC_MUX0_CFG0 +
+				VA_MACRO_ADC_MUX_CFG_OFFSET * decimator;
+	adapt_ctrl = CDC_VA_CDC_ADPT0_ADPT_CTRL +
+				VA_MACRO_TX_PATH_OFFSET *decimator;
 
 	switch (event) {
 	case SND_SOC_DAPM_PRE_PMU:
@@ -1034,6 +1063,9 @@ static int va_macro_enable_dec(struct snd_soc_dapm_widget *w,
 		/* Enable TX PGA Mute */
 		break;
 	case SND_SOC_DAPM_POST_PMU:
+		if (va->codec_version == LPASS_CODEC_VERSION_4_0)
+			snd_soc_component_update_bits(comp, adapt_ctrl, 0xFF, 0x00);
+
 		/* Enable TX CLK */
 		snd_soc_component_update_bits(comp, tx_vol_ctl_reg,
 					      CDC_VA_TX_PATH_CLK_EN_MASK,
@@ -1042,7 +1074,13 @@ static int va_macro_enable_dec(struct snd_soc_dapm_widget *w,
 					      CDC_VA_TX_HPF_ZERO_GATE_MASK,
 					      CDC_VA_TX_HPF_ZERO_GATE);
 
-		usleep_range(1000, 1010);
+		if (!is_amic_enabled(comp, decimator)) {
+			snd_soc_component_update_bits(comp, hpf_gate_reg,
+						      CDC_VA_TX_HPF_ZERO_GATE_MASK,
+						      CDC_VA_TX_HPF_ZERO_GATE);
+			usleep_range(1000, 1010);
+		}
+
 		hpf_cut_off_freq = (snd_soc_component_read(comp, dec_cfg_reg) &
 				    TX_HPF_CUT_OFF_FREQ_MASK) >> 5;
 
@@ -1050,22 +1088,24 @@ static int va_macro_enable_dec(struct snd_soc_dapm_widget *w,
 			snd_soc_component_update_bits(comp, dec_cfg_reg,
 						      TX_HPF_CUT_OFF_FREQ_MASK,
 						      CF_MIN_3DB_150HZ << 5);
-
-			snd_soc_component_update_bits(comp, hpf_gate_reg,
-				      CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_MASK,
-				      CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_REQ);
-
-			/*
-			 * Minimum 1 clk cycle delay is required as per HW spec
-			 */
-			usleep_range(1000, 1010);
-
-			snd_soc_component_update_bits(comp,
-				hpf_gate_reg,
-				CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_MASK,
-				0x0);
 		}
 
+		snd_soc_component_update_bits(comp, hpf_gate_reg,
+					      CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_MASK,
+					      CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_REQ);
+
+		/*
+		 * Minimum 1 clk cycle delay is required as per HW spec
+		 */
+
+		usleep_range(1000, 1010);
+
+		if (!is_amic_enabled(comp, decimator)) {
+			snd_soc_component_update_bits(comp,
+						      hpf_gate_reg,
+						      CDC_VA_TX_HPF_CUTOFF_FREQ_CHANGE_MASK,
+						      0x0);
+		}
 
 		usleep_range(1000, 1010);
 		snd_soc_component_update_bits(comp, hpf_gate_reg,
@@ -1544,6 +1584,12 @@ static const struct snd_soc_dapm_route va_audio_map[] = {
 	{"VA DMIC MUX3", "DMIC5", "VA DMIC5"},
 	{"VA DMIC MUX3", "DMIC6", "VA DMIC6"},
 	{"VA DMIC MUX3", "DMIC7", "VA DMIC7"},
+
+	/* SWR_MIC routes: connect each VA DECx MUX to its SWR_MIC input */
+	{"VA DEC0 MUX", "SWR_MIC", "VA SWR_MIC0"},
+	{"VA DEC1 MUX", "SWR_MIC", "VA SWR_MIC1"},
+	{"VA DEC2 MUX", "SWR_MIC", "VA SWR_MIC2"},
+	{"VA DEC3 MUX", "SWR_MIC", "VA SWR_MIC3"},
 
 	{ "VA DMIC0", NULL, "DMIC0 Pin" },
 	{ "VA DMIC1", NULL, "DMIC1 Pin" },

--- a/sound/soc/codecs/wsa885x-i2c.c
+++ b/sound/soc/codecs/wsa885x-i2c.c
@@ -196,6 +196,11 @@
 #define FU21_VOL_STEPS 124
 static const DECLARE_TLV_DB_SCALE(fu21_digital_gain, -8400, 100, 0);
 
+/*TDM Slots*/
+#define WSA885X_TDM8 0X08
+#define WSA885X_TDM4 0X04
+#define WSA885X_TDM2 0X02
+
 static const char *const supply_name[] = {
 	"vdd-io",
 	"vdd-1p8",
@@ -408,13 +413,21 @@ static int wsa885x_gpio_set(struct wsa885x_i2c_priv *wsa885x, bool val)
 	return ret;
 }
 
-static void reg_update_sequence(struct regmap *regmap)
+static void reg_update_sequence(struct regmap *regmap, int slots)
 {
 	regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL1, 0x15);
 	regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL1, 0x11);
 
 	/* Configure TDM control register 0 */
-	regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL0, 0x04);
+	if (slots == WSA885X_TDM2)
+		regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL0, 0x0);
+	else if (slots == WSA885X_TDM4)
+		regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL0, 0x04);
+	else if (slots == WSA885X_TDM8)
+		regmap_write(regmap, DIG_CTRL1_I2S_TDM_CTL0, 0xC);
+	else
+		pr_warn("Invalid TDM slot count: %d, expected 2, 4, or 8\n", slots);
+
 	regmap_update_bits(regmap, DIG_CTRL1_I2S_TDM_CTL0, 0x01, 0x01);
 
 	/* Configure TDM transmit channel settings */
@@ -616,7 +629,7 @@ static int codec_set_tdm_slot(struct snd_soc_dai *dai,
 		regmap_update_bits(wsa885x->regmap, DIG_CTRL1_I2S_CFG1_TDM_TX,
 						   0x60, 0x60);
 		/* Apply TDM control sequence */
-		reg_update_sequence(wsa885x->regmap);
+		reg_update_sequence(wsa885x->regmap, slots);
 		/* Enable transmit channels */
 		regmap_update_bits(wsa885x->regmap, DIG_CTRL1_I2S_TDM_CH_TX,
 						   0x04, 0x04);
@@ -630,7 +643,7 @@ static int codec_set_tdm_slot(struct snd_soc_dai *dai,
 		/* Configure slot1 for current protection sense 0 */
 		regmap_update_bits(wsa885x->regmap, DIG_CTRL1_I2S_CFG0_TDM_TX,
 						   0x50, 0x50);
-		reg_update_sequence(wsa885x->regmap);
+		reg_update_sequence(wsa885x->regmap, slots);
 	} else if (wsa885x->rx_slot_mask == WSA885X_CHANNEL_MONO_RIGHT) {
 		/* Mono right channel configuration */
 		/* Configure slot0 for I-sense channel 1 */
@@ -639,7 +652,7 @@ static int codec_set_tdm_slot(struct snd_soc_dai *dai,
 		/* Configure slot1 for current protection sense 1 */
 		regmap_update_bits(wsa885x->regmap, DIG_CTRL1_I2S_CFG0_TDM_TX,
 						   0x60, 0x60);
-		reg_update_sequence(wsa885x->regmap);
+		reg_update_sequence(wsa885x->regmap, slots);
 	}
 
 	/* Enable I2S control */
@@ -719,6 +732,93 @@ static int codec_set_sysclk(struct snd_soc_dai *dai, int clk_id,
 	return 0;
 }
 
+static int wsa885x_handle_ssr_reset(struct wsa885x_i2c_priv *wsa885x)
+{
+	int ret;
+
+	/*
+	 * Re-toggle shutdown GPIO to force codec out of a potential SSR/fault
+	 * state, then keep PA FSM disabled until power-up reconfiguration.
+	 */
+	if (wsa885x->sd_n) {
+		dev_dbg(wsa885x->component->dev, "%s: asserting powerdown gpio\n",
+			__func__);
+		ret = wsa885x_gpio_set(wsa885x, true);
+		if (ret) {
+			dev_err(wsa885x->component->dev,
+				"%s: failed to assert powerdown gpio: %d\n",
+				__func__, ret);
+			return ret;
+		}
+
+		usleep_range(1000, 1500);
+
+		dev_dbg(wsa885x->component->dev, "%s: deasserting powerdown gpio\n",
+			__func__);
+		ret = wsa885x_gpio_set(wsa885x, false);
+		if (ret) {
+			dev_err(wsa885x->component->dev,
+				"%s: failed to deassert powerdown gpio: %d\n",
+				__func__, ret);
+			return ret;
+		}
+
+		usleep_range(2000, 2500);
+	} else {
+		dev_dbg(wsa885x->component->dev,
+			"%s: no powerdown gpio, skip gpio reset sequence\n", __func__);
+	}
+
+	regmap_write(wsa885x->regmap, DIG_CTRL0_PA_FSM_CTL, 0x00);
+	dev_dbg(wsa885x->component->dev, "%s: PA FSM disabled\n", __func__);
+	return 0;
+}
+
+static int reinit_wsa885x_powerup(struct wsa885x_i2c_priv *wsa885x)
+{
+	int ret = 0;
+	int ps = 0;
+
+	ret = wsa885x_handle_ssr_reset(wsa885x);
+	if (ret) {
+		dev_err(wsa885x->component->dev, "SSR reset failed: %d\n", ret);
+		return ret;
+	}
+
+	dev_dbg(wsa885x->component->dev, "%s: programming reinit sequence\n",
+		__func__);
+	regmap_write(wsa885x->regmap, DIG_CTRL0_PA_FSM_CTL, 0x00);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_OT23_USAGE,
+		     wsa885x->usage_mode);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_IT21_CLUSERINDEX, 0x01);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_PPU21_POSTURENUMBER, 0x01);
+
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_FU21_CH_VOL_CH2X0_MSB,
+		     wsa885x->stereo_voldB);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_FU21_CH_VOL_CH2X0_LSB, 0x00);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_FU21_CH_VOL_CH2X1_MSB,
+		     wsa885x->stereo_voldB);
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_FU21_CH_VOL_CH2X1_LSB, 0x00);
+	regmap_write(wsa885x->regmap, DIG_CTRL0_SDCA_COMMIT, 0x01);
+	dev_dbg(wsa885x->component->dev,
+		"%s: committed usage=%u vol_db=%d cluster=1 posture=1\n",
+		__func__, wsa885x->usage_mode, wsa885x->stereo_voldB);
+
+	regmap_write(wsa885x->regmap, SMP_AMP_CTRL_STEREO_PDE23_REQ_PS, 0x00);
+	dev_dbg(wsa885x->component->dev, "%s: requested PS%d\n", __func__, ps);
+
+	ret = wait_for_pde_state(wsa885x, ps, SMP_AMP_CTRL_STEREO_PDE23_ACT_PS);
+	if (!ret) {
+		dev_dbg(wsa885x->component->dev,
+			"Successfully transitioned to power state %d\n", ps);
+	} else {
+		dev_err(wsa885x->component->dev,
+			"Failed transitioned to power state %d\n", ps);
+	}
+
+	return ret;
+}
+
 static int codec_mute_stream(struct snd_soc_dai *dai, int mute, int stream)
 {
 	struct wsa885x_i2c_priv *wsa885x = snd_soc_dai_get_drvdata(dai);
@@ -771,7 +871,9 @@ static int codec_mute_stream(struct snd_soc_dai *dai, int mute, int stream)
 					"Successfully transitioned to power state %d\n", ps0);
 		} else {
 			dev_err(wsa885x->component->dev, "PS0 request failed\n");
-			goto exit;
+			ret = reinit_wsa885x_powerup(wsa885x);
+			if (ret)
+				goto exit;
 		}
 
 		/* Configure power amplifier based on channel configuration */
@@ -1047,7 +1149,7 @@ static const struct snd_kcontrol_new wsa885x_snd_controls[] = {
 			   wsa885x_stereo_gain_offset_put,
 			   fu21_digital_gain),
 
-	SOC_SINGLE_EXT("Rx Slot Mask", SND_SOC_NOPM, 0, 4, 0,
+	SOC_SINGLE_EXT("Rx Slot Mask", SND_SOC_NOPM, 0, 3, 0,
 			   wsa885x_i2c_rx_slot_mask_get,
 			   wsa885x_i2c_rx_slot_mask_put),
 };
@@ -1336,6 +1438,8 @@ static const struct of_device_id wsa885x_i2c_dt_match[] = {
 		.compatible = "qcom,wsa885x-i2c",
 	},
 	{}};
+
+MODULE_DEVICE_TABLE(of, wsa885x_i2c_dt_match);
 
 static const struct i2c_device_id wsa885x_id_i2c[] = {
 	{"wsa885x_i2c", 0},

--- a/sound/soc/qcom/common.c
+++ b/sound/soc/qcom/common.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2018, Linaro Limited.
 // Copyright (c) 2018, The Linux Foundation. All rights reserved.
 
+#include <dt-bindings/sound/qcom,lpass.h>
 #include <dt-bindings/sound/qcom,q6afe.h>
 #include <linux/module.h>
 #include <sound/jack.h>
@@ -236,6 +237,7 @@ int qcom_snd_wcd_jack_setup(struct snd_soc_pcm_runtime *rtd,
 	case TX_CODEC_DMA_TX_1:
 	case TX_CODEC_DMA_TX_2:
 	case TX_CODEC_DMA_TX_3:
+	case LPASS_CDC_DMA_VA_TX1:
 		for_each_rtd_codec_dais(rtd, i, codec_dai) {
 			rval = snd_soc_component_set_jack(codec_dai->component,
 							  jack, NULL);

--- a/sound/soc/qcom/sc8280xp.c
+++ b/sound/soc/qcom/sc8280xp.c
@@ -172,6 +172,7 @@ static const struct of_device_id snd_sc8280xp_dt_match[] = {
 	{.compatible = "qcom,qcs9075-sndcard", "sa8775p"},
 	{.compatible = "qcom,qcs9100-sndcard", "sa8775p"},
 	{.compatible = "qcom,sc8280xp-sndcard", "sc8280xp"},
+	{.compatible = "qcom,shikra-sndcard", "shikra"},
 	{.compatible = "qcom,sm8450-sndcard", "sm8450"},
 	{.compatible = "qcom,sm8550-sndcard", "sm8550"},
 	{.compatible = "qcom,sm8650-sndcard", "sm8650"},

--- a/sound/soc/qcom/sc8280xp.c
+++ b/sound/soc/qcom/sc8280xp.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2022, Linaro Limited
 
+#include <dt-bindings/sound/qcom,lpass.h>
 #include <dt-bindings/sound/qcom,q6afe.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
@@ -86,6 +87,7 @@ static int sc8280xp_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
 	case TX_CODEC_DMA_TX_1:
 	case TX_CODEC_DMA_TX_2:
 	case TX_CODEC_DMA_TX_3:
+	case LPASS_CDC_DMA_VA_TX1:
 		channels->min = 1;
 		break;
 	default:
@@ -127,7 +129,7 @@ static void sc8280xp_add_be_ops(struct snd_soc_card *card)
 	int i;
 
 	for_each_card_prelinks(card, i, link) {
-		if (link->no_pcm == 1) {
+		if (link->no_pcm == 1 || link->num_codecs > 0) {
 			link->init = sc8280xp_snd_init;
 			link->be_hw_params_fixup = sc8280xp_be_hw_params_fixup;
 			link->ops = &sc8280xp_be_ops;

--- a/sound/soc/qcom/sdw.c
+++ b/sound/soc/qcom/sdw.c
@@ -41,6 +41,7 @@ static bool qcom_snd_is_sdw_dai(int id)
 	switch (id) {
 	case LPASS_CDC_DMA_TX3:
 	case LPASS_CDC_DMA_RX0:
+	case LPASS_CDC_DMA_VA_TX1:
 		return true;
 	default:
 		break;


### PR DESCRIPTION
This series introduces Shikra platform audio support for Qualcomm-based SoCs, including enabling SoundWire microphone functionality and updating related codec, macro, and machine driver components.

Key Changes

Added SoundWire microphone support in LPASS VA macro.
Enabled Shikra platform support in the SC8280XP machine driver.
Added LPASS codec v4.0 support required for Shikra.
Introduced Shikra sound card DT bindings.
Added RX and VA macro codec DT bindings for Shikra.
Updated SoundWire master bindings with qcom,swr-master-ee-val property.
Enhanced SoundWire driver with EE-aware register layout and CPU selection.
Improved WSA885x codec driver with slot-aware TDM control sequencing.
Fixed SC8280XP driver to support Shikra CQM configuration.