### PR TITLE
arm64: dts: qcom: shikra: Enable audio on shikra-cqm-evk

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -8,6 +8,7 @@
 #include "shikra-cqm-som.dtsi"
 #include "shikra-evk.dtsi"
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/sound/qcom,lpass.h>
 
 / {
 	model = "Qualcomm Technologies, Inc. Shikra CQM EVK";
@@ -35,6 +36,96 @@
 		enable-active-high;
 		pinctrl-0 = <&lcd_bias_en>;
 		pinctrl-names = "default";
+	};
+
+	mi2s_tdm_sen: mi2s-tdm-sen-qaif-aif {
+		qcom,qaif-aif-bits-per-lane = <2>;
+		qcom,qaif-aif-ctrl-data-oe = <1>;
+		qcom,qaif-aif-full-cycle-en = <0>;
+		qcom,qaif-aif-invert-sync = <0>;
+		qcom,qaif-aif-lane-config = <1 1>, <1 0>;
+		qcom,qaif-aif-loopback-en = <0>;
+		qcom,qaif-aif-mono-mode-tx = <0>;
+		qcom,qaif-aif-mono-mode-rx = <0>;
+		qcom,qaif-aif-sample-width-rx = <16>;
+		qcom,qaif-aif-sample-width-tx = <16>;
+		qcom,qaif-aif-slot-width-rx = <32>;
+		qcom,qaif-aif-slot-width-tx = <32>;
+		qcom,qaif-aif-slot-en-rx-mask = <0x3>;
+		qcom,qaif-aif-slot-en-tx-mask = <0x3>;
+		qcom,qaif-aif-sync-delay = <1>;
+		qcom,qaif-aif-sync-mode = <1>;
+		qcom,qaif-aif-sync-src = <1>;
+		qcom,qaif-intf-dai-id = <34>;
+	};
+
+	sound: sound {
+		compatible = "qcom,shikra-sndcard";
+		model = "shikra-cqm-evk";
+
+		audio-routing = "IN1_HPHL", "HPHL_OUT",
+				"IN2_HPHR", "HPHR_OUT",
+				"AMIC2", "MIC BIAS2",
+				"VA DMIC0", "vdd-micb",
+				"VA DMIC1", "vdd-micb",
+				"VA DMIC2", "vdd-micb",
+				"VA DMIC3", "vdd-micb",
+				"VA SWR_MIC0", "ADC2_OUTPUT";
+
+		pinctrl-0 = <&i2s2_default>, <&dmic_eldo_en_defualt>;
+		pinctrl-names = "default";
+
+		headset-capture-dai-link {
+			link-name = "Headphones Capture";
+
+			codec {
+				sound-dai = <&pmic4125_codec 1>,
+					    <&swr1 0>,
+					    <&vamacro 0>;
+			};
+
+			cpu {
+				sound-dai = <&qaif_cpu LPASS_CDC_DMA_VA_TX1>;
+			};
+		};
+
+		headset-playback-dai-link {
+			link-name = "Headphones Playback";
+
+			codec {
+				sound-dai = <&pmic4125_codec 0>,
+					    <&swr0 0>,
+					    <&rxmacro 0>;
+			};
+
+			cpu {
+				sound-dai = <&qaif_cpu LPASS_CDC_DMA_RX0>;
+			};
+		};
+
+		wsa-speaker-dai-link {
+			link-name = "WSA Speaker Playback";
+
+			codec {
+				sound-dai = <&wsa885x_i2c>;
+			};
+
+			cpu {
+				sound-dai = <&qaif_cpu MI2S_SENARY>;
+			};
+		};
+
+		va-dmic-dai-link {
+			link-name = "VA DMIC Capture";
+
+			codec {
+				sound-dai = <&vamacro 0>;
+			};
+
+			cpu {
+				sound-dai = <&qaif_cpu LPASS_CDC_DMA_VA_TX0>;
+			};
+		};
 	};
 
 	wcn3988-pmu {
@@ -71,6 +162,54 @@
 				regulator-name = "vreg_pmu_ch1";
 			};
 		};
+	};
+};
+
+&i2c3 {
+	status = "okay";
+
+	wsa885x_i2c: wsa885x-i2c-codec@c {
+		compatible = "qcom,wsa885x-i2c";
+		reg = <0x0c>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&wsa885x_i2c_spkr_sd_n>;
+
+		interrupt-gpios = <&tlmm 77 GPIO_ACTIVE_HIGH>;
+		powerdown-gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+		vdd-1p8-supply = <&pm4125_l15>;
+		vdd-io-supply = <&pm4125_l15>;
+		qcom,battery_config = <2>;
+
+		wsa885x-init-table =
+			<0x8470 0x2   /* DIG_CTRL0_CDC_RXTX_FSCNT_CTL - FS_CNT_CLR(1) */
+			0x8470 0x0   /* DIG_CTRL0_CDC_RXTX_FSCNT_CTL - FS_CNT_CLR(0) */
+			0x8470 0x1   /* DIG_CTRL0_CDC_RXTX_FSCNT_CTL - FS_CNT_EN(1) */
+			0x0004 0x1   /* SMP_AMP_CTRL_STEREO_CMT_GRP_MASK - CMT_GRP_MASK(1) */
+			0x8602 0x60  /* CDC_RX0_RX_PATH_CFG1 - HPF_EN(0) */
+			0x8622 0x60  /* CDC_RX1_RX_PATH_CFG1 - HPF_EN(0) */
+			0x8458 0x79  /* PANDEIRO_DIG_CTRL0_VBAT_THRM_FLT_CTL - VBAT_COEF_SEL */
+			0x810B 0xD9  /* PANDEIRO_ANA_TOP_SPK_TOP_PWRSTG_CH1_TUNE3 */
+			0x8111 0xD9  /* PANDEIRO_ANA_TOP_SPK_TOP_PWRSTG_CH2_TUNE3 */
+			0x813C 0x08  /* SPK_TOP_COMMON_CTRL4 - override_ctl*/
+			0x8102 0x04  /* PANDEIROI2S.TOP.PANDEIRO_ANA_TOP*/
+			0x811C 0x29  /* PANDEIROI2S.TOP.PANDEIRO_ANA_TOP.SPK_TOP_LF_CH1_CTRL11.*/
+			0x811D 0x40  /* PANDEIRO_ANA_TOP_SPK_TOP_LF_CH1_TUNE1  - HIZ_DELAY_PROG*/
+			0x8129 0x40  /* PANDEIRO_ANA_TOP_SPK_TOP_LF_CH2_TUNE1  - HIZ_DELAY_PROG*/
+			0x811A 0x80  /* PANDEIRO_ANA_TOP_SPK_TOP_LF_CH1_CTRL9 */
+			0x8126 0x80  /* PANDEIRO_ANA_TOP_SPK_TOP_LF_CH2_CTRL9 */
+			0x8103 0x6   /* PANDEIRO_ANA_TOP_SPK_TOP_COMMON_TUNE1 - GAIN_TUNE */
+			0x80CA 0x85  /* PANDEIRO_ANA_TOP_IVSENSE_ADC_MODE_CTL2 */
+			0x80CB 0xE   /* PANDEIRO_ANA_TOP_IVSENSE_ADC_MODE_CTL3 */
+			0x80CC 0xC   /* PANDEIRO_ANA_TOP_IVSENSE_ADC_REF_CTL */
+			0x80D0 0x80 /* PANDEIRO_ANA_TOP_IVSENSE_ADC_CDAC_CAL_CTL2 */
+			0x80BA 0xC0 /* PANDEIROI2S.TOP.PANDEIRO_ANA_TOP.SPK_TOP_SPARE3 */
+			0x841C 0x4E /* PANDEIROI2S.TOP.PANDEIRO_DIG_CTRL */
+			0x8435 0x47 /* PANDEIRO_DIG_CTRL0_PA1_FSM_CTL1 - SILENT_STATE_IVS_EN */
+			0x86CE 0x09 /* PANDEIROI2S.TOP.CDC_CLSH_CDC_CLSH.V1P8_BP_CTL2.BP_CNT */
+			0x8667 0x34 /* CDC_COMPANDER1_CTL7 - AGAIN_DELAY */
+			0x800D 0x08>; /* PANDEIROI2S.TOP.PANDEIRO_ANA_TOP.PON_CKSK_CTL_0 */
+		#sound-dai-cells = <0>;
 	};
 };
 
@@ -136,6 +275,11 @@
 	remote-endpoint = <&usb_qmpphy_out>;
 };
 
+&qaif_cpu {
+	aif-interface = <&mi2s_tdm_sen>;
+	status = "okay";
+};
+
 &remoteproc_cdsp {
 	firmware-name = "qcom/shikra/cdsp.mbn";
 
@@ -152,6 +296,10 @@
 &remoteproc_mpss {
 	firmware-name = "qcom/shikra/qdsp6sw.mbn";
 
+	status = "okay";
+};
+
+&rxmacro {
 	status = "okay";
 };
 
@@ -187,8 +335,104 @@
 	status = "okay";
 };
 
+&spmi_bus {
+	pmic@0 {
+		pmic4125_codec: audio-codec@f000 {
+			compatible = "qcom,pm4125-codec";
+			reg = <0xf000>;
+			vdd-io-supply = <&pm4125_l15>;
+			vdd-cp-supply = <&pm4125_s1>;
+			vdd-pa-vpos-supply = <&pm4125_s1>;
+
+			vdd-mic-bias-supply = <&pm4125_l22>;
+			qcom,micbias1-microvolt = <1800000>;
+			qcom,micbias2-microvolt = <1800000>;
+			qcom,micbias3-microvolt = <1800000>;
+
+			qcom,mbhc-buttons-vthreshold-microvolt = <75000 150000 237000 500000
+								  500000 500000 500000 500000>;
+			qcom,mbhc-headset-vthreshold-microvolt = <1700000>;
+			qcom,mbhc-headphone-vthreshold-microvolt = <50000>;
+
+			qcom,rx-device = <&pm4125_rx>;
+			qcom,tx-device = <&pm4125_tx>;
+			#sound-dai-cells = <1>;
+
+			status = "okay";
+		};
+	};
+};
+
+&swr0 {
+	status = "okay";
+
+	pm4125_rx: codec@0,4 {
+		compatible = "sdw20217010c00";
+		reg = <0 4>;
+		qcom,rx-port-mapping = <1 2 3 4 5>;
+	};
+};
+
+&swr1 {
+	status = "okay";
+
+	pm4125_tx: codec@0,3 {
+		compatible = "sdw20217010c00";
+		reg = <0 3>;
+		qcom,tx-port-mapping = <2 3>;
+	};
+};
+
 &tlmm {
 	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+
+	dmic01_default: dmic01-default-state {
+		clk-pins {
+			pins = "gpio96";
+			function = "dmic";
+			drive-strength = <8>;
+			output-high;
+		};
+
+		data-pins {
+			pins = "gpio97";
+			function = "dmic";
+			drive-strength = <8>;
+			input-enable;
+		};
+	};
+
+	dmic23_default: dmic23-default-state {
+		clk-pins {
+			pins = "gpio98";
+			function = "dmic";
+			drive-strength = <8>;
+			output-high;
+		};
+
+		data-pins {
+			pins = "gpio99";
+			function = "dmic";
+			drive-strength = <8>;
+			input-enable;
+		};
+	};
+
+	dmic_eldo_en_defualt: dmic_eldo_en_default {
+		pins = "gpio71";
+		function = "gpio";
+		drive-strength = <8>;   /* 8 mA */
+		bias-disable;
+		output-high;
+	};
+
+	i2s2_default: i2s2-default-active-state {
+		pins = "gpio100", "gpio101", "gpio102", "gpio103";
+		function = "i2s2";
+		drive-strength = <8>;
+		output-high;
+		bias-disable;
+	};
 
 	lcd_bias_en: lcd-bias-en-state {
 		pins = "gpio151";
@@ -224,6 +468,12 @@
 		bias-pull-down;
 	};
 
+	wsa885x_i2c_spkr_sd_n: wsa885x-i2c-spkr-sd-n-active-state {
+		pins = "gpio2";
+		function = "gpio";
+		input-disable;
+		output-enable;
+	};
 };
 
 &uart0 {
@@ -279,4 +529,12 @@
 
 &usb_qmpphy_out {
 	remote-endpoint = <&pm4125_ss_in>;
+};
+
+&vamacro {
+	pinctrl-0 = <&dmic01_default>, <&dmic23_default>, <&swr_tx_clk>, <&swr_tx_data0>;
+	pinctrl-names = "default";
+
+	qcom,dmic-sample-rate = <4800000>;
+	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -16,6 +16,7 @@
 #include <dt-bindings/interconnect/qcom,shikra.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <dt-bindings/power/qcom-rpmpd.h>
+#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
 #include <dt-bindings/thermal/thermal.h>
 
 / {
@@ -1006,6 +1007,41 @@
 				function = "gpio";
 				drive-strength = <2>;
 				bias-pull-up;
+			};
+
+			swr_rx_clk: swr-rx-clk {
+				pins = "gpio107";
+				function = "swr0_rx";
+				drive-strength = <8>;
+				bias-disable;
+			};
+
+			swr_rx_data0: swr-rx-data0 {
+				pins = "gpio108";
+				function = "swr0_rx";
+				drive-strength = <8>;
+				bias-bus-hold;
+			};
+
+			swr_rx_data1: swr-rx-data1 {
+				pins = "gpio109";
+				function = "swr0_rx";
+				drive-strength = <8>;
+				bias-bus-hold;
+			};
+
+			swr_tx_clk: swr-tx-clk {
+				pins = "gpio105";
+				function = "swr0_tx";
+				drive-strength = <8>;
+				bias-disable;
+			};
+
+			swr_tx_data0: swr-tx-data0 {
+				pins = "gpio106";
+				function = "swr0_tx";
+				drive-strength = <8>;
+				bias-bus-hold;
 			};
 		};
 
@@ -2045,7 +2081,7 @@
 			reg = <0x0 0x0a000000 0x0 0x20000>;
 			reg-names = "audio-qaif-core";
 
-			interrupts = <GIC_SPI 331 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 331 IRQ_TYPE_LEVEL_HIGH 0>;
 			interrupt-names = "qaif-irq-audio-core";
 
 			clocks = <&gcc GCC_LPASS_CONFIG_CLK>,
@@ -2083,6 +2119,116 @@
 
 			#sound-dai-cells = <1>;
 			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+
+		rxmacro: codec@a040000 {
+			compatible = "qcom,shikra-lpass-rx-macro";
+			reg = <0x0 0x0a040000 0x0 0x1000>;
+
+			pinctrl-0 = <&swr_rx_clk>, <&swr_rx_data0>, <&swr_rx_data1>;
+			pinctrl-names = "default";
+
+			clocks = <&audiocorecc AUDIO_CORE_CC_RX_MCLK_CLK>,
+				<&audiocorecc AUDIO_CORE_CC_RX_MCLK_2X_CLK>,
+				 <&vamacro>;
+			clock-names = "mclk",
+				      "npl",
+				      "fsgen";
+
+			#clock-cells = <0>;
+			clock-output-names = "mclk";
+			#sound-dai-cells = <1>;
+
+			status = "disabled";
+		};
+
+		swr0: soundwire@a060000 {
+			compatible = "qcom,soundwire-v3.1.0";
+			reg = <0x0 0x0a060000 0x0 0x10000>;
+			qcom,swr-master-ee-val = <0>;
+
+			interrupts = <GIC_SPI 330 IRQ_TYPE_LEVEL_HIGH 0>;
+
+			clocks = <&rxmacro>;
+			clock-names = "iface";
+
+			label = "RX";
+			qcom,din-ports = <0>;
+			qcom,dout-ports = <5>;
+
+			resets = <&audiocorecc AUDIO_CORE_CSR_RX_SWR_CGCR>;
+			reset-names = "swr_audio_cgcr";
+
+			qcom,ports-sinterval-low =	/bits/ 8 <0x03 0x1f 0x1f 0x07 0x00>;
+			qcom,ports-offset1 =		/bits/ 8 <0x00 0x00 0x0b 0x01 0x00>;
+			qcom,ports-offset2 =		/bits/ 8 <0x00 0x00 0x0b 0x00 0x00>;
+			qcom,ports-hstart =		/bits/ 8 <0xff 0x03 0xff 0xff 0xff>;
+			qcom,ports-hstop =		/bits/ 8 <0xff 0x06 0xff 0xff 0xff>;
+			qcom,ports-word-length =	/bits/ 8 <0x01 0x07 0x04 0xff 0xff>;
+			qcom,ports-block-pack-mode =	/bits/ 8 <0xff 0x00 0x01 0xff 0xff>;
+			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff 0x00>;
+			qcom,ports-lane-control =	/bits/ 8 <0x01 0x00 0x00 0x00 0x00>;
+
+			#sound-dai-cells = <1>;
+			#address-cells = <2>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+
+		vamacro: codec@a078000 {
+			compatible = "qcom,shikra-lpass-va-macro";
+			reg = <0x0 0x0a078000 0x0 0x2000>;
+
+			pinctrl-0 = <&swr_tx_clk>, <&swr_tx_data0>;
+			pinctrl-names = "default";
+
+			clocks = <&audiocorecc AUDIO_CORE_CC_TX_MCLK_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_TX_MCLK_2X_CLK>;
+			clock-names = "mclk",
+				      "npl";
+
+			#clock-cells = <0>;
+			#sound-dai-cells = <1>;
+			clock-output-names = "fsgen";
+			status = "disabled";
+		};
+
+		swr1: soundwire@a080000 {
+			compatible = "qcom,soundwire-v3.1.0";
+			reg = <0x0 0x0a080000 0x0 0x10000>;
+			qcom,swr-master-ee-val = <0>;
+
+			interrupts = <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH 0>,
+				     <GIC_SPI 406 IRQ_TYPE_LEVEL_HIGH 0>;
+			interrupt-names = "core", "wakeup";
+
+			clocks = <&vamacro>;
+			clock-names = "iface";
+
+			label = "VA_TX";
+
+			qcom,din-ports = <3>;
+			qcom,dout-ports = <0>;
+
+			resets = <&audiocorecc AUDIO_CORE_CSR_TX_SWR_CGCR>;
+			reset-names = "swr_audio_cgcr";
+
+			qcom,ports-sinterval-low =      /bits/ 8 <0x01 0x03 0x03>;
+			qcom,ports-offset1 =            /bits/ 8 <0x00 0x01 0x01>;
+			qcom,ports-offset2 =            /bits/ 8 <0x00 0x00 0x00>;
+			qcom,ports-hstart =             /bits/ 8 <0xff 0xff 0xff>;
+			qcom,ports-hstop =              /bits/ 8 <0xff 0xff 0xff>;
+			qcom,ports-word-length =        /bits/ 8 <0xff 0xff 0xff>;
+			qcom,ports-block-pack-mode =    /bits/ 8 <0xff 0xff 0xff>;
+			qcom,ports-block-group-count =  /bits/ 8 <0xff 0xff 0xff>;
+			qcom,ports-lane-control =       /bits/ 8 <0x00 0x01 0x00>;
+
+			#sound-dai-cells = <1>;
+			#address-cells = <2>;
 			#size-cells = <0>;
 
 			status = "disabled";

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -2040,6 +2040,54 @@
 			#power-domain-cells = <1>;
 		};
 
+		qaif_cpu: audio@a000000 {
+			compatible = "qcom,shikra-qaif-cpu";
+			reg = <0x0 0x0a000000 0x0 0x20000>;
+			reg-names = "audio-qaif-core";
+
+			interrupts = <GIC_SPI 331 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "qaif-irq-audio-core";
+
+			clocks = <&gcc GCC_LPASS_CONFIG_CLK>,
+				 <&gcc GCC_LPASS_CORE_AXIM_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AUD_DMA_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AUD_DMA_MEM_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_BUS_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF0_EBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF0_IBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF1_EBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF1_IBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF2_EBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF2_IBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF3_EBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_AIF_IF3_IBIT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_EXT_MCLKA_OUT_CLK>,
+				 <&audiocorecc AUDIO_CORE_CC_EXT_MCLKB_OUT_CLK>;
+			clock-names = "gcc_lpass_config_clk",
+					  "gcc_lpass_core_axim_clk",
+					  "audio_core_cc_aud_dma_clk",
+					  "audio_core_cc_aud_dma_mem_clk",
+					  "audio_core_cc_bus_clk",
+					  "audio_core_cc_aif_if0_ebit_clk",
+					  "audio_core_cc_aif_if0_ibit_clk",
+					  "audio_core_cc_aif_if1_ebit_clk",
+					  "audio_core_cc_aif_if1_ibit_clk",
+					  "audio_core_cc_aif_if2_ebit_clk",
+					  "audio_core_cc_aif_if2_ibit_clk",
+					  "audio_core_cc_aif_if3_ebit_clk",
+					  "audio_core_cc_aif_if3_ibit_clk",
+					  "audio_core_cc_ext_mclka_clk",
+					  "audio_core_cc_ext_mclkb_clk";
+
+			iommus = <&apps_smmu 0x1c0 0x0>;
+
+			#sound-dai-cells = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+
 		sram@c11e000 {
 			compatible = "qcom,shikra-imem", "syscon", "simple-mfd";
 			reg = <0x0 0x0c11e000 0x0 0x1000>;


### PR DESCRIPTION
This PR enables audio support on the Shikra platform by adding required Device Tree nodes for QAIF CPU interface, SoundWire devices, and sound card configuration for the CQM EVK.

The following changes are introduced as part of audio bring-up on Shikra:
QAIF CPU device node to support CPU-based audio path.
Required for platforms where audio use cases are processed on CPU instead of DSP.
SoundWire master and slave device nodes.
On Shikra, SoundWire master is connected via the VA macro, which differs from other platforms.
Enable sound card node for shikra-cqm-evk.
Completes the audio path enabling playback/record use cases.