### PR TITLE
arm64: dts: qcom: shikra: Fix wcn3988-pmu node on EVK boards

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -40,12 +40,15 @@
 	wcn3988-pmu {
 		compatible = "qcom,wcn3988-pmu";
 
+		pinctrl-0 = <&sw_ctrl_default>;
+		pinctrl-names = "default";
+
 		vddio-supply = <&pm4125_l7>;
 		vddxo-supply = <&pm4125_l13>;
 		vddrf-supply = <&pm4125_l10>;
 		vddch0-supply = <&pm4125_l22>;
 
-		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+		swctrl-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
 
 		regulators {
 			vreg_pmu_io: ldo0 {
@@ -62,6 +65,10 @@
 
 			vreg_pmu_ch0: ldo3 {
 				regulator-name = "vreg_pmu_ch0";
+			};
+
+			vreg_pmu_ch1: ldo4 {
+				regulator-name = "vreg_pmu_ch1";
 			};
 		};
 	};
@@ -206,6 +213,12 @@
 		pins = "gpio86";
 		function = "mdp_vsync_p";
 		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	sw_ctrl_default: sw-ctrl-default-state {
+		pins = "gpio88";
+		function = "gpio";
 		bias-pull-down;
 	};
 

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -40,12 +40,15 @@
 	wcn3988-pmu {
 		compatible = "qcom,wcn3988-pmu";
 
+		pinctrl-0 = <&sw_ctrl_default>;
+		pinctrl-names = "default";
+
 		vddio-supply = <&pm4125_l7>;
 		vddxo-supply = <&pm4125_l13>;
 		vddrf-supply = <&pm4125_l10>;
 		vddch0-supply = <&pm4125_l22>;
 
-		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+		swctrl-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
 
 		regulators {
 			vreg_pmu_io: ldo0 {
@@ -62,6 +65,10 @@
 
 			vreg_pmu_ch0: ldo3 {
 				regulator-name = "vreg_pmu_ch0";
+			};
+
+			vreg_pmu_ch1: ldo4 {
+				regulator-name = "vreg_pmu_ch1";
 			};
 		};
 	};
@@ -208,6 +215,13 @@
 		drive-strength = <2>;
 		bias-pull-down;
 	};
+
+	sw_ctrl_default: sw-ctrl-default-state {
+		pins = "gpio88";
+		function = "gpio";
+		bias-pull-down;
+	};
+
 };
 
 &uart0 {

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -58,12 +58,15 @@
 	wcn3988-pmu {
 		compatible = "qcom,wcn3988-pmu";
 
+		pinctrl-0 = <&sw_ctrl_default>;
+		pinctrl-names = "default";
+
 		vddio-supply = <&pm8150_s4>;
 		vddxo-supply = <&pm8150_l12>;
 		vddrf-supply = <&pm8150_l8>;
 		vddch0-supply = <&vreg_wcn_3p3>;
 
-		bt-enable-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
+		swctrl-gpios = <&tlmm 88 GPIO_ACTIVE_HIGH>;
 
 		regulators {
 			vreg_pmu_io: ldo0 {
@@ -80,6 +83,10 @@
 
 			vreg_pmu_ch0: ldo3 {
 				regulator-name = "vreg_pmu_ch0";
+			};
+
+			vreg_pmu_ch1: ldo4 {
+				regulator-name = "vreg_pmu_ch1";
 			};
 		};
 	};
@@ -217,6 +224,12 @@
 		pins = "gpio86";
 		function = "mdp_vsync_p";
 		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	sw_ctrl_default: sw-ctrl-default-state {
+		pins = "gpio88";
+		function = "gpio";
 		bias-pull-down;
 	};
 };


### PR DESCRIPTION
incremental PR building on #1251, this PR renames bt-enable-gpios to swctrl-gpios, add sw_ctrl_default pinctrl state for gpio88, and add missing vreg_pmu_ch1 (ldo4) regulator to wcn3988-pmu node across cqm-evk, cqs-evk and iqs-evk boards.