### PR TITLE
FROMLIST: mmc: sdhci-msm: Set ice clk rate

### DIFF
--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -275,6 +275,7 @@ struct sdhci_msm_host {
 	/* core, iface, cal and sleep clocks */
 	struct clk_bulk_data bulk_clks[4];
 #ifdef CONFIG_MMC_CRYPTO
+	struct clk *ice_clk;	/* ICE clock */
 	struct qcom_ice *ice;
 #endif
 	unsigned long clk_rate;
@@ -2593,6 +2594,17 @@ static int sdhci_msm_probe(struct platform_device *pdev)
 		if (ret)
 			return ret;
 	}
+
+#ifdef CONFIG_MMC_CRYPTO
+	/* Setup ICE clock */
+	msm_host->ice_clk = devm_clk_get(&pdev->dev, "ice");
+	if (!IS_ERR(msm_host->ice_clk)) {
+		/* Vote for max. clk rate for max. performance */
+		ret = clk_set_rate(msm_host->ice_clk, INT_MAX);
+		if (ret)
+			dev_err(&pdev->dev, "ice clk set rate failed (%d)\n", ret);
+	}
+#endif
 
 	/* Setup main peripheral bus clock */
 	clk = devm_clk_get(&pdev->dev, "iface");


### PR DESCRIPTION
Set ice clk rate from sdhci msm platform driver, needed for target which are having legacy ice support, and need sdhci msm platform driver to set rate.

Link: https://lore.kernel.org/all/20260529081045.2877910-2-ram.gupta@oss.qualcomm.com/
CRs-Fixed: 4445554