### PR TITLE
PENDING: arm64: dts: qcom: shikra: add reboot-mode support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
@@ -17,6 +17,13 @@
 	status = "okay";
 };
 
+&psci {
+	reboot-mode {
+		mode-bootloader = <0x10001 0x2>;
+		mode-edl = <0 0x1>;
+	};
+};
+
 &qupv3_0 {
 	firmware-name = "qcom/shikra/qupv3fw.elf";
 	status = "okay";

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -281,7 +281,7 @@
 		interrupts = <GIC_PPI 5 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
-	psci {
+	psci: psci {
 		compatible = "arm,psci-1.0";
 		method = "smc";
 	};


### PR DESCRIPTION
Add a label to the psci node in shikra.dtsi to allow board files to override it. Add reboot-mode child nodes to the CQM, CQS, and IQS EVK board DTS files to configure fastboot (mode-bootloader) and EDL (mode-edl) reboot modes.