### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: Add OPP-table for ICE UFS device node

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -2806,6 +2806,32 @@
 				     "qcom,inline-crypto-engine";
 			reg = <0x0 0x01d88000 0x0 0x18000>;
 			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>;
+
+			operating-points-v2 = <&ice_opp_table>;
+
+			ice_opp_table: opp-table {
+				compatible = "operating-points-v2";
+
+				opp-75000000 {
+					opp-hz = /bits/ 64 <75000000>;
+					required-opps = <&rpmhpd_opp_svs_l1>;
+				};
+
+				opp-150000000 {
+					opp-hz = /bits/ 64 <150000000>;
+					required-opps = <&rpmhpd_opp_svs_l1>;
+				};
+
+				opp-300000000 {
+					opp-hz = /bits/ 64 <300000000>;
+					required-opps = <&rpmhpd_opp_nom>;
+				};
+
+				opp-600000000 {
+					opp-hz = /bits/ 64 <600000000>;
+					required-opps = <&rpmhpd_opp_nom>;
+				};
+			};
 		};
 
 		cryptobam: dma-controller@1dc4000 {


### PR DESCRIPTION
Qualcomm Inline Crypto Engine (ICE) platform driver now supports an optional OPP-table.

Add OPP-table for ICE UFS device nodes for LeMans platform.

Testing:
* dtbs_check
* Validated on LeMans-evk platform

Link: https://lore.kernel.org/all/20260530-add-opp-table-for-lemans-ice-ufs-v2-1-2b46d3ac37d5@oss.qualcomm.com/
Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>
CRs-Fixed: 4554448