### PR TITLE
arm64: dts: qcom: shikra: migrate WiFi power control to pwrseq

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -268,9 +268,9 @@
 
 &wifi {
 	vdd-0.8-cx-mx-supply = <&pm4125_l7>;
-	vdd-1.8-xo-supply = <&pm4125_l13>;
-	vdd-1.3-rfa-supply = <&pm4125_l10>;
-	vdd-3.3-ch0-supply = <&pm4125_l22>;
+	vdd-1.8-xo-supply = <&vreg_pmu_xo>;
+	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
+	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
 	firmware-name = "cq2390";
 

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -272,9 +272,9 @@
 
 &wifi {
 	vdd-0.8-cx-mx-supply = <&pm4125_l7>;
-	vdd-1.8-xo-supply = <&pm4125_l13>;
-	vdd-1.3-rfa-supply = <&pm4125_l10>;
-	vdd-3.3-ch0-supply = <&pm4125_l22>;
+	vdd-1.8-xo-supply = <&vreg_pmu_xo>;
+	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
+	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
 	firmware-name = "cq2390";
 

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -49,14 +49,6 @@
 			pinctrl-0 = <&lcd_bias_en>;
 			pinctrl-names = "default";
 		};
-
-		vreg_wlan_3p3_dummy: regulator-wlan-3p3-dummy {
-			compatible = "regulator-fixed";
-			regulator-name = "wlan_3p3_dummy";
-			regulator-min-microvolt = <3300000>;
-			regulator-max-microvolt = <3300000>;
-			regulator-always-on;
-		};
 	};
 
 	vreg_wcn_3p3: regulator-wcn-3p3 {
@@ -292,9 +284,9 @@
 
 &wifi {
 	vdd-0.8-cx-mx-supply = <&pm8150_s4>;
-	vdd-1.8-xo-supply = <&pm8150_l12>;
-	vdd-1.3-rfa-supply = <&pm8150_l8>;
-	vdd-3.3-ch0-supply = <&vreg_wlan_3p3_dummy>;
+	vdd-1.8-xo-supply = <&vreg_pmu_xo>;
+	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
+	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
 	firmware-name = "cq2390";
 


### PR DESCRIPTION
Switch WiFi supply nodes to PMU regulators and move power control from driver to pwrseq, aligning with the Bluetooth power model.

Also remove unused dummy WLAN 3.3V regulator.