### PR TITLE
TEST: rpmsg: glink: CI pipeline validation commit - do not merge

### DIFF
--- a/drivers/rpmsg/qcom_glink_smem.c
+++ b/drivers/rpmsg/qcom_glink_smem.c
@@ -374,5 +374,5 @@ void qcom_glink_smem_unregister(struct qcom_glink_smem *smem)
 EXPORT_SYMBOL_GPL(qcom_glink_smem_unregister);
 
 MODULE_AUTHOR("Bjorn Andersson <bjorn.andersson@linaro.org>");
-MODULE_DESCRIPTION("Qualcomm GLINK SMEM driver");
+MODULE_DESCRIPTION("Qualcomm GLINK SMEM driver [CI-TEST: dev-ci rootfs validation]");
 MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
This commit is added purely to validate Dev-CI pipeline behaviour for the tech/mproc/rpmsg topic branch. Specifically, it tests whether pre-merge rootfs generation is restored after the branch-filter change introduced in kernel-config PR #200 (May 13 2026).

This commit should NOT be merged and must be reverted after testing.