### PR TITLE
PENDING: arm64: dts: qcom: kaanapali: add Coresight ETR and routing in staging dtso

### DIFF
--- a/arch/arm64/boot/dts/qcom/kaanapali-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/kaanapali-staging.dtso
@@ -9,12 +9,203 @@
 /plugin/;
 
 &soc {
+	ctcu: ctcu@10001000 {
+		compatible = "qcom,sa8775p-ctcu";
+		reg = <0x0 0x10001000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb";
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				ctcu_in0: endpoint {
+					remote-endpoint = <&tmc_etr_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				ctcu_in1: endpoint {
+					remote-endpoint = <&tmc_etr1_out>;
+				};
+			};
+		};
+	};
+
+	replicator_qdss: replicator@10046000 {
+		compatible = "arm,coresight-dynamic-replicator", "arm,primecell";
+		reg = <0x0 0x10046000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		in-ports {
+			port {
+				replicator_qdss_in: endpoint {
+					remote-endpoint = <&replicator_swao_out0>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				replicator_qdss_out: endpoint {
+					remote-endpoint = <&replicator_etr_in>;
+				};
+			};
+		};
+	};
+
+	tmc_etr: tmc@10048000 {
+		compatible = "arm,coresight-tmc", "arm,primecell";
+		reg = <0x0 0x10048000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		iommus = <&apps_smmu 0x04e0 0x0>;
+		arm,scatter-gather;
+
+		in-ports {
+			port {
+				tmc_etr_in: endpoint {
+					remote-endpoint = <&replicator_etr_out0>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				tmc_etr_out: endpoint {
+					remote-endpoint = <&ctcu_in0>;
+				};
+			};
+		};
+	};
+
+	replicator_etr: replicator@1004e000 {
+		compatible = "arm,coresight-dynamic-replicator", "arm,primecell";
+		reg = <0x0 0x1004e000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		in-ports {
+			port {
+				replicator_etr_in: endpoint {
+					remote-endpoint = <&replicator_qdss_out>;
+				};
+			};
+		};
+
+		out-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				replicator_etr_out0: endpoint {
+					remote-endpoint = <&tmc_etr_in>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				replicator_etr_out1: endpoint {
+					remote-endpoint = <&tmc_etr1_in>;
+				};
+			};
+		};
+	};
+
+	tmc_etr1: tmc@1004f000 {
+		compatible = "arm,coresight-tmc", "arm,primecell";
+		reg = <0x0 0x1004f000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		iommus = <&apps_smmu 0x0500 0x0>;
+		arm,scatter-gather;
+
+		in-ports {
+			port {
+				tmc_etr1_in: endpoint {
+					remote-endpoint = <&replicator_etr_out1>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				tmc_etr1_out: endpoint {
+					remote-endpoint = <&ctcu_in1>;
+				};
+			};
+		};
+	};
+
 	tgu@11301000 {
 		compatible = "qcom,tgu", "arm,primecell";
 		reg = <0x0 0x11301000 0x0 0x1000>;
 
 		clocks = <&aoss_qmp>;
 		clock-names = "apb_pclk";
+	};
+
+	tmc@11305000 {
+		out-ports {
+			port {
+				tmc_etf_out: endpoint {
+					remote-endpoint = <&replicator_swao_in>;
+				};
+			};
+		};
+	};
+
+	replicator_swao: replicator@11306000 {
+		compatible = "arm,coresight-dynamic-replicator", "arm,primecell";
+		reg = <0x0 0x11306000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		in-ports {
+			port {
+				replicator_swao_in: endpoint {
+					remote-endpoint = <&tmc_etf_out>;
+				};
+			};
+		};
+
+		out-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				replicator_swao_out0: endpoint {
+					remote-endpoint = <&replicator_qdss_in>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				replicator_swao_out1: endpoint {
+					remote-endpoint = <&eud_in>;
+				};
+			};
+		};
 	};
 
 	tgu@1130e000 {


### PR DESCRIPTION
Add CTCU, QDSS replicator, dual ETR (tmc_etr/tmc_etr1), ETR replicator, SWAO replicator, and tmc_etf out-port to complete the DDR memory trace routing path in the kaanapali staging overlay.