### PR TITLE
dt-bindings: firmware: qcom,scm: complete shikra clock constraints

### DIFF
--- a/Documentation/devicetree/bindings/firmware/qcom,scm.yaml
+++ b/Documentation/devicetree/bindings/firmware/qcom,scm.yaml
@@ -147,6 +147,7 @@ allOf:
               - qcom,scm-msm8974
               - qcom,scm-msm8976
               - qcom,scm-qcm2290
+              - qcom,scm-shikra
               - qcom,scm-sm6375
     then:
       required:
@@ -166,6 +167,7 @@ allOf:
               - qcom,scm-msm8660
               - qcom,scm-msm8960
               - qcom,scm-qcm2290
+              - qcom,scm-shikra
               - qcom,scm-sm6375
     then:
       properties:


### PR DESCRIPTION
Extend the incomplete shikra binding by adding qcom,scm-shikra to the allOf blocks that enforce clock requirements and constrain clock count.