### PR TITLE
QCLINUX: arm64: dts: qcom: monaco: Add SAIL Mailbox device tree overlay

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -516,6 +516,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= monaco-camx-el2.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= monaco-evk-staging.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= monaco-staging.dtbo
+dtb-$(CONFIG_ARCH_QCOM)	+= monaco-sail-mb.dtbo
 
 purwa-evk-camx-dtbs     := purwa-iot-evk.dtb purwa-evk-camx.dtbo
 

--- a/arch/arm64/boot/dts/qcom/monaco-sail-mb.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-sail-mb.dtso
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/mailbox/qcom-ipcc.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&soc {
+	ipcc_computeL1: qcom,ipcc@488000 {
+		compatible = "qcom,ipcc";
+		reg = <0x0 0x00488000 0x0 0x1000>;
+		interrupts = <GIC_SPI 231 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#mbox-cells = <2>;
+		num_mbox_chans = <5>;
+	};
+
+	sail_mailbox: sail-mailbox@1ffe02c {
+		compatible = "qcom,sail-mailbox";
+		reg = <0x0 0x01FFE02C 0x0 0x10>,
+		      <0x0 0x01FFD018 0x0 0x10>,
+		      <0x0 0x17C0000C 0x0 0x04>;
+		mboxes = <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0x2>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL1 0x3>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0x4>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0x5>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0x6>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0x7>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL2 0x8>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL1 0x9>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL2 0xa>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL1 0xb>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0xc>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL0 0xd>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL1 0xe>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL2 0xf>,
+			 <&ipcc_computeL1 IPCC_CLIENT_SAIL3 0x10>;
+		memory-region = <&sail_mailbox_mem>,
+				<&sail_ota_mem>;
+		interrupt-parent = <&ipcc_computeL1>;
+		interrupts = <IPCC_CLIENT_SAIL0 0x2 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL1 0x3 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0x4 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0x5 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0x6 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0x7 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL2 0x8 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL1 0x9 IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL2 0xa IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL1 0xb IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0xc IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL0 0xd IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL1 0xe IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL2 0xf IRQ_TYPE_EDGE_RISING>,
+			     <IPCC_CLIENT_SAIL3 0x10 IRQ_TYPE_EDGE_RISING>;
+		sail-handshake-delay = <50000>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add monaco-sail-mb.dtso overlay for Monaco (QCS8300/QCS8275) platform providing:
  - ipcc_computeL1: IPCC Compute-L1 controller
  - sail_mailbox: SAIL Mailbox device node.

CRs-Fixed: 4560313