### PR TITLE
arm64: dts: qcom: shikra-iqs-evk: add audio machine support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -51,6 +51,75 @@
 		};
 	};
 
+	sound {
+		compatible = "qcom,shikra-sndcard";
+		model = "shikra-iqs-evk";
+
+		pinctrl-0 = <&i2s0_clk>, <&i2s0_ws>, <&i2s0_data>, <&ext_mclk2_active>;
+		pinctrl-names = "default";
+
+		audio-routing = "IN34", "Headset Mic",
+				"Headset Mic", "MICBIAS",
+				"DMICL", "Int Mic",
+				"Int Mic", "MICBIAS",
+				"Headphone", "HPL",
+				"Headphone", "HPR",
+				"Speaker", "SPKL",
+				"Speaker", "SPKR",
+				"VA DMIC0", "vdd-micb",
+				"VA DMIC1", "vdd-micb",
+				"VA DMIC2", "vdd-micb",
+				"VA DMIC3", "vdd-micb";
+
+		va-dmic-dai-link {
+			link-name = "VA DMIC Capture";
+
+			cpu {
+				sound-dai = <&q6apmbedai VA_CODEC_DMA_TX_0>;
+			};
+
+			codec {
+				sound-dai = <&vamacro 0>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
+
+		pri-i2s-playback-dai-link {
+			link-name = "Analog Playback";
+
+			cpu {
+				sound-dai = <&q6apmbedai PRIMARY_MI2S_RX>;
+			};
+
+			codec {
+				sound-dai = <&max98091>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
+
+		pri-i2s-capture-dai-link {
+			link-name = "Analog Capture";
+
+			cpu {
+				sound-dai = <&q6apmbedai PRIMARY_MI2S_TX>;
+			};
+
+			codec {
+				sound-dai = <&max98091>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
+	};
+
 	vreg_wcn_3p3: regulator-wcn-3p3 {
 		compatible = "regulator-fixed";
 		regulator-name = "wcn_3p3";
@@ -102,6 +171,25 @@
 
 &gpu_zap_shader {
 	firmware-name = "qcom/shikra/a704_zap.mbn";
+};
+
+&i2c3 {
+	status = "okay";
+
+	max98091: audio-codec@10 {
+		compatible = "maxim,max98091";
+		reg = <0x10>;
+
+		pinctrl-0 = <&max98091_default>;
+		pinctrl-names = "default";
+
+		interrupts-extended = <&tlmm 28 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&q6prmcc LPASS_CLK_ID_MCLK_2 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+		clock-names = "mclk";
+		assigned-clocks = <&q6prmcc LPASS_CLK_ID_MCLK_2 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+		assigned-clock-rates = <12288000>;
+		#sound-dai-cells = <0>;
+	};
 };
 
 &i2c4 {
@@ -169,6 +257,17 @@
 	};
 };
 
+&q6apmbedai {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	dai@16 {
+		reg = <PRIMARY_MI2S_RX>;
+		clocks = <&q6prmcc LPASS_CLK_ID_AUD_INTF0_IBIT LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+		clock-names = "bclk";
+	};
+};
+
 &remoteproc_cdsp {
 	firmware-name = "qcom/shikra/cdsp.mbn";
 
@@ -223,6 +322,74 @@
 &tlmm {
 	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
 
+	dmic01_default: dmic01-default-state {
+		clk-pins {
+			pins = "gpio96";
+			function = "dmic";
+			drive-strength = <8>;
+			output-high;
+		};
+
+		data-pins {
+			pins = "gpio97";
+			function = "dmic";
+			drive-strength = <8>;
+			input-enable;
+		};
+	};
+
+	dmic23_default: dmic23-default-state {
+		clk-pins {
+			pins = "gpio98";
+			function = "dmic";
+			drive-strength = <8>;
+			output-high;
+		};
+
+		data-pins {
+			pins = "gpio99";
+			function = "dmic";
+			drive-strength = <8>;
+			input-enable;
+		};
+	};
+
+	dmic_eldo_en_default: dmic-eldo-en-default-state {
+		pins = "gpio71";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+		output-high;
+	};
+
+	ext_mclk2_active: ext-mclk2-state {
+		pins = "gpio110";
+		function = "ext_mclk";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	i2s0_clk: i2s0-clk-active-state {
+		pins = "gpio105";
+		function = "i2s0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	i2s0_data: i2s0-data-active-state {
+		pins = "gpio107", "gpio108", "gpio109";
+		function = "i2s0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	i2s0_ws: i2s0-ws-active-state {
+		pins = "gpio106";
+		function = "i2s0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
 	lt9611_irq_pin: lt9611-irq-state {
 		pins = "gpio85";
 		function = "gpio";
@@ -237,6 +404,12 @@
 		drive-strength = <8>;
 		output-high;
 		input-disable;
+	};
+
+	max98091_default: max98091-default-state {
+		pins = "gpio28";
+		function = "gpio";
+		bias-pull-up;
 	};
 
 	sw_ctrl_default: sw-ctrl-default-state {
@@ -278,6 +451,19 @@
 &usb_qmpphy {
 	vdda-phy-supply = <&pm8150_l6>;
 	vdda-pll-supply = <&pm8150_l12>;
+
+	status = "okay";
+};
+
+&vamacro {
+	clocks = <&q6prmcc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+		 <&q6prmcc LPASS_CLK_ID_TX_CORE_NPL_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+	clock-names = "mclk", "npl";
+
+	pinctrl-0 = <&dmic01_default>, <&dmic23_default>, <&dmic_eldo_en_default>;
+	pinctrl-names = "default";
+
+	qcom,dmic-sample-rate = <4800000>;
 
 	status = "okay";
 };


### PR DESCRIPTION
Enable the audio machine description on the Shikra IQS EVK board.

Add the sound card node, VA-DMIC capture and analog playback/capture links, MAX98091 codec wiring, audio-related pinctrl states, and required LPASS clock references.