### PR TITLE
add IMEM and PIL regions

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -7738,6 +7738,22 @@
 			};
 		};
 
+		sram@14680000 {
+			compatible = "qcom,glymur-imem", "mmio-sram";
+			reg = <0x0 0x14680000 0x0 0x2c000>;
+			ranges = <0 0 0x14680000 0x2c000>;
+
+			no-memory-wc;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			pil-sram@94c {
+				compatible = "qcom,pil-reloc-info";
+				reg = <0x94c 0xc8>;
+			};
+		};
+
 		apps_smmu: iommu@15000000 {
 			compatible = "qcom,glymur-smmu-500",
 				     "qcom,smmu-500",


### PR DESCRIPTION
…glymur

Add an IMEM on glymur which falls back to mmio-sram and define the PIL relocation info region as its child, for post mortem tools to locate the loaded remoteprocs.

Link: https://lore.kernel.org/lkml/20260424-glymur-imem-v5-2-18ede63cf063@oss.qualcomm.com/#r