### PR TITLE
GPU blocking XO Shutdown

### DIFF
--- a/drivers/gpu/drm/msm/adreno/a6xx_gmu.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_gmu.c
@@ -642,7 +642,7 @@ static void a6xx_rpmh_stop(struct a6xx_gmu *gmu)
 	int ret;
 	u32 val;
 
-	if (test_and_clear_bit(GMU_STATUS_FW_START, &gmu->status))
+	if (!test_and_clear_bit(GMU_STATUS_FW_START, &gmu->status))
 		return;
 
 	if (adreno_is_a840(adreno_gpu))
@@ -1464,6 +1464,9 @@ static void a6xx_gmu_shutdown(struct a6xx_gmu *gmu)
 
 	/* Stop the interrupts and mask the hardware */
 	a6xx_gmu_irq_disable(gmu);
+
+	/* Halt the gmu cm3 core */
+	gmu_write(gmu, REG_A6XX_GMU_CM3_SYSRESET, 1);
 
 	/* Tell RPMh to power off the GPU */
 	a6xx_rpmh_stop(gmu);


### PR DESCRIPTION
There are stale RPMH votes (BCM votes) observed after GMU suspend. This is because the rpmh stop sequences are skipped during gmu suspend. Fix this and also move GMU to reset state to avoid any further activity.

Link: https://lore.kernel.org/all/20260605-assorted-fixes-june-v1-1-2caa04f7287c@oss.qualcomm.com/

Fixes: f248d5d5159a ("drm/msm/a6xx: Fix PDC sleep sequence")

qli-2.0 GA Critical Fix

CRs-Fixed:  4536581