### PR TITLE
arm64: dts: qcom: shikra: Update RPMCC node

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -313,7 +313,7 @@
 				qcom,glink-channels = "rpm_requests";
 
 				rpmcc: clock-controller {
-					compatible = "qcom,rpmcc-shikra", "qcom,rpmcc";
+					compatible = "qcom,rpmcc-shikra", "qcom,rpmcc-qcm2290", "qcom,rpmcc";
 					clocks = <&xo_board>;
 					clock-names = "xo";
 					#clock-cells = <1>;


### PR DESCRIPTION
As per the updated bindings changes, use the Agatti RPMCC compatible as fallback for Shikra.

https://github.com/qualcomm-linux/kernel-topics/pull/1330
https://lore.kernel.org/all/20260608-shikra-gcc-rpmcc-clks-v5-0-94cefe092ee3@oss.qualcomm.com/T/#t