### PR TITLE
arm64: dts: qcom: shikra: configure WSA TDM audio

### DIFF
--- a/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
+++ b/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
@@ -63,6 +63,11 @@ properties:
       List of phandles pointing to auxiliary devices, such
       as amplifiers, to be added to the sound card.
 
+  qcom,adsp-bypass-mode:
+    type: boolean
+    description:
+      Indicates the platform is configured for ADSP bypass mode.
+
   model:
     $ref: /schemas/types.yaml#/definitions/string
     description: User visible long sound card name

--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -63,6 +63,7 @@
 		compatible = "qcom,shikra-sndcard";
 		model = "shikra-cqm-evk";
 
+		qcom,adsp-bypass-mode;
 		audio-routing = "IN1_HPHL", "HPHL_OUT",
 				"IN2_HPHR", "HPHR_OUT",
 				"AMIC2", "MIC BIAS2",

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -64,10 +64,16 @@
 
 			cpu {
 				sound-dai = <&q6apmbedai SECONDARY_TDM_RX_0>;
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				dai-tdm-slot-rx-mask = <1 1>;
 			};
 
 			codec {
 				sound-dai = <&wsa885x_i2c>;
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				dai-tdm-slot-rx-mask = <1 1>;
 			};
 
 			platform {
@@ -237,6 +243,17 @@
 
 &pm4125_ss_in {
 	remote-endpoint = <&usb_qmpphy_out>;
+};
+
+&q6apmbedai {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dai@40 {
+		reg = <SECONDARY_TDM_RX_0>;
+		clocks = <&q6prmcc LPASS_CLK_ID_AUD_INTF2_IBIT
+			  LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+		clock-names = "bclk";
+	};
 };
 
 &remoteproc_cdsp {


### PR DESCRIPTION
Configure the Shikra CQS EVK WSA playback link for the secondary TDM RX interface used by the external WSA codec.

Add the two-slot 32-bit TDM slot configuration on both CPU and codec DAI endpoints, and describe the SECONDARY_TDM_RX_0 BCLK supplied through q6prmcc. Also allow child DAI nodes under q6apmbedai by adding address and size cells.