### PR TITLE
WORKAROUND: firmware: efi: libstub: delete LoaderTpm2ActivePcrBanks

### DIFF
--- a/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c
@@ -438,6 +438,15 @@ static int qcom_smmu_init_context(struct arm_smmu_domain *smmu_domain,
 	int cbndx = smmu_domain->cfg.cbndx;
 
 	smmu_domain->cfg.flush_walk_prefer_tlbiasid = true;
+	/*
+	 * Qualcomm SMMU-500 has an issue with TLBIVA/TLBIVAL where only
+	 * the base-page-size entry at the base IOVA is invalidated. Glymur
+	 * SoCs boot by default at EL2 and is the currently the only SoC
+	 * affected by it. Force the minimum page granule to ensure the full
+	 * range is covered.
+	 */
+	if (of_device_is_compatible(smmu->dev->of_node, "qcom,glymur-smmu-500"))
+		smmu_domain->cfg.force_min_tlbival_granule = true;
 
 	client_match = qsmmu->data->client_match;
 

--- a/drivers/iommu/arm/arm-smmu/arm-smmu.c
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu.c
@@ -286,6 +286,16 @@ static void arm_smmu_tlb_inv_range_s1(unsigned long iova, size_t size,
 	struct arm_smmu_cfg *cfg = &smmu_domain->cfg;
 	int idx = cfg->cbndx;
 
+	/*
+	 * Override the step granule with the minimum supported page size.
+	 * Placed here (rather than in tlb_add_page alone) to cover both
+	 * TLBIVAL and TLBIVA paths.
+	 */
+	if (cfg->force_min_tlbival_granule) {
+		WARN_ON_ONCE(!smmu_domain->domain.pgsize_bitmap);
+		granule = 1UL << __ffs(smmu_domain->domain.pgsize_bitmap);
+	}
+
 	if (smmu->features & ARM_SMMU_FEAT_COHERENT_WALK)
 		wmb();
 

--- a/drivers/iommu/arm/arm-smmu/arm-smmu.h
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu.h
@@ -359,6 +359,7 @@ struct arm_smmu_cfg {
 	enum arm_smmu_cbar_type		cbar;
 	enum arm_smmu_context_fmt	fmt;
 	bool				flush_walk_prefer_tlbiasid;
+	bool				force_min_tlbival_granule;
 };
 #define ARM_SMMU_INVALID_IRPTNDX	0xff
 


### PR DESCRIPTION
On Glymur, enabling QSEECOM exposes EFI boot variables to userspace, including LoaderTpm2ActivePcrBanks written by systemd-boot. Systemd reads this variable to detect TPM2 availability and activates tpm2.target, which waits for /dev/tpm0. Since the TPM firmware (SPSS) is non-functional on Glymur linux, /dev/tpm0 is never created and systemd stalls for the full 90-second device timeout, causing kernel CI failures.

The boot team identified that no other SoC will have this variable set and we can safely delete it. So delete LoaderTpm2ActivePcrBanks early in the EFI stub before systemd can read it, preventing tpm2.target activation.