### PR TITLE
Revert "media: qcom: camss: add support for QCM2390 camss"

### DIFF
--- a/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
+++ b/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
@@ -1010,7 +1010,6 @@ static bool csiphy_is_gen2(u32 version)
 
 	switch (version) {
 	case CAMSS_2290:
-	case CAMSS_2390:
 	case CAMSS_6150:
 	case CAMSS_7280:
 	case CAMSS_8250:
@@ -1102,7 +1101,6 @@ static int csiphy_init(struct csiphy_device *csiphy)
 		regs->lane_array_size = ARRAY_SIZE(lane_regs_sdm845);
 		break;
 	case CAMSS_2290:
-	case CAMSS_2390:
 	case CAMSS_6150:
 		regs->lane_regs = &lane_regs_qcm2290[0];
 		regs->lane_array_size = ARRAY_SIZE(lane_regs_qcm2290);

--- a/drivers/media/platform/qcom/camss/camss-vfe.c
+++ b/drivers/media/platform/qcom/camss/camss-vfe.c
@@ -342,7 +342,6 @@ static u32 vfe_src_pad_code(struct vfe_line *line, u32 sink_code,
 		break;
 	case CAMSS_660:
 	case CAMSS_2290:
-	case CAMSS_2390:
 	case CAMSS_6150:
 	case CAMSS_7280:
 	case CAMSS_8x96:

--- a/drivers/media/platform/qcom/camss/camss.c
+++ b/drivers/media/platform/qcom/camss/camss.c
@@ -5160,18 +5160,6 @@ static const struct camss_resources qcm2290_resources = {
 	.vfe_num = ARRAY_SIZE(vfe_res_2290),
 };
 
-static const struct camss_resources qcm2390_resources = {
-	.version = CAMSS_2390,
-	.csiphy_res = csiphy_res_2290,
-	.csid_res = csid_res_2290,
-	.vfe_res = vfe_res_2290,
-	.icc_res = icc_res_2290,
-	.icc_path_num = ARRAY_SIZE(icc_res_2290),
-	.csiphy_num = ARRAY_SIZE(csiphy_res_2290),
-	.csid_num = ARRAY_SIZE(csid_res_2290),
-	.vfe_num = ARRAY_SIZE(vfe_res_2290),
-};
-
 static const struct camss_resources qcs8300_resources = {
 	.version = CAMSS_8300,
 	.pd_name = "top",
@@ -5340,7 +5328,6 @@ static const struct of_device_id camss_dt_match[] = {
 	{ .compatible = "qcom,sdm660-camss", .data = &sdm660_resources },
 	{ .compatible = "qcom,sdm670-camss", .data = &sdm670_resources },
 	{ .compatible = "qcom,sdm845-camss", .data = &sdm845_resources },
-	{ .compatible = "qcom,shikra-camss", .data = &qcm2390_resources },
 	{ .compatible = "qcom,sm6150-camss", .data = &sm6150_resources },
 	{ .compatible = "qcom,sm8250-camss", .data = &sm8250_resources },
 	{ .compatible = "qcom,sm8550-camss", .data = &sm8550_resources },

--- a/drivers/media/platform/qcom/camss/camss.h
+++ b/drivers/media/platform/qcom/camss/camss.h
@@ -80,7 +80,6 @@ enum pm_domain {
 enum camss_version {
 	CAMSS_660,
 	CAMSS_2290,
-	CAMSS_2390,
 	CAMSS_6150,
 	CAMSS_7280,
 	CAMSS_8x16,


### PR DESCRIPTION
Currently camera is broken on qcom-next.

Reverting this commit as the changes need to be handled in legacy PHY way,
which has already been merged in the camss topic branch yesterday.

PR: https://github.com/qualcomm-linux/kernel-topics/pull/1363