### PR TITLE
interconnect: qcom: Enable Shikra interconnect driver by default for …

### DIFF
--- a/drivers/interconnect/qcom/Kconfig
+++ b/drivers/interconnect/qcom/Kconfig
@@ -287,6 +287,7 @@ config INTERCONNECT_QCOM_SHIKRA
 	tristate "Qualcomm SHIKRA interconnect driver"
 	depends on INTERCONNECT_QCOM
 	depends on QCOM_SMD_RPM
+	default ARCH_QCOM
 	select INTERCONNECT_QCOM_SMD_RPM
 	help
 	  This is a driver for the Qualcomm Network-on-Chip on shikra-based


### PR DESCRIPTION
…ARCH_QCOM

Interconnect drivers provide fundamental NoC bandwidth management required for correct system behavior. Although systems can boot without them, power and performance are impacted.
These drivers need to enabled irresepective of the board variant, design or configuration.

Enable the Shikra interconnect driver by default on ARCH_QCOM by setting
 "default ARCH_QCOM".


Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
Link: https://lore.kernel.org/r/20260526-shikra_icc_kconfig-v1-1-c589db2d023c@oss.qualcomm.com