### PR TITLE
wifi: ath11k: fix NULL pointer dereference in ath11k_hal_srng_access_beginTech/net/ath

### DIFF
--- a/drivers/net/wireless/ath/ath11k/qmi.c
+++ b/drivers/net/wireless/ath/ath11k/qmi.c
@@ -3295,9 +3295,14 @@ static void ath11k_qmi_driver_event_work(struct work_struct *work)
 			clear_bit(ATH11K_FLAG_CRASH_FLUSH,
 				  &ab->dev_flags);
 			clear_bit(ATH11K_FLAG_RECOVERY, &ab->dev_flags);
-			ath11k_core_qmi_firmware_ready(ab);
-			set_bit(ATH11K_FLAG_REGISTERED, &ab->dev_flags);
-
+			if (!test_bit(ATH11K_FLAG_REGISTERED, &ab->dev_flags)) {
+				ret = ath11k_core_qmi_firmware_ready(ab);
+				if (ret) {
+					set_bit(ATH11K_FLAG_QMI_FAIL, &ab->dev_flags);
+					break;
+				}
+				set_bit(ATH11K_FLAG_REGISTERED, &ab->dev_flags);
+			}
 			break;
 		case ATH11K_QMI_EVENT_COLD_BOOT_CAL_DONE:
 			break;

--- a/drivers/net/wireless/ath/ath12k/dp_rx.c
+++ b/drivers/net/wireless/ath/ath12k/dp_rx.c
@@ -565,6 +565,9 @@ static int ath12k_dp_prepare_reo_update_elem(struct ath12k_dp *dp,
 
 	lockdep_assert_held(&dp->dp_lock);
 
+	if (!peer->primary_link)
+		return 0;
+
 	elem = kzalloc_obj(*elem, GFP_ATOMIC);
 	if (!elem)
 		return -ENOMEM;

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -13326,6 +13326,7 @@ int ath12k_mac_op_get_survey(struct ieee80211_hw *hw, int idx,
 	struct ath12k *ar;
 	struct ieee80211_supported_band *sband;
 	struct survey_info *ar_survey;
+	int orig_idx = idx;
 
 	lockdep_assert_wiphy(hw->wiphy);
 
@@ -13360,7 +13361,7 @@ int ath12k_mac_op_get_survey(struct ieee80211_hw *hw, int idx,
 		return -ENOENT;
 	}
 
-	ar_survey = &ar->survey[idx];
+	ar_survey = &ar->survey[orig_idx];
 
 	ath12k_mac_update_bss_chan_survey(ar, &sband->channels[idx]);
 


### PR DESCRIPTION
    In ATH11K_QMI_EVENT_FW_READY, ATH11K_FLAG_REGISTERED is set
    unconditionally even when ath11k_core_qmi_firmware_ready() fails.
    This leaves the driver in an inconsistent state where
    initialization is considered complete although the firmware ready
    handling did not finish successfully. During the subsequent SSR,
    the driver enters the restart path based on this incorrect state
    and dereferences uninitialized srng members, resulting in a NULL
    pointer dereference.

    Call trace:
      ath11k_hal_srng_access_begin+0xc/0x60 [ath11k] (P)
      ath11k_ce_cleanup_pipes+0x17c/0x180 [ath11k]
      ath11k_core_restart+0x40/0x168 [ath11k]

    Fix this by:
    - skipping firmware_ready if ATH11K_FLAG_REGISTERED is already set
    - setting ATH11K_FLAG_REGISTERED only when firmware_ready succeeds
    - setting ATH11K_FLAG_QMI_FAIL and aborting the FW_READY handling
    on error
