### PR TITLE
Bluetooth: qca: Add BT FW build version to kernel log

### DIFF
--- a/drivers/bluetooth/btqca.c
+++ b/drivers/bluetooth/btqca.c
@@ -143,6 +143,8 @@ static int qca_read_fw_build_info(struct hci_dev *hdev)
 
 	hci_set_fw_info(hdev, "%s", build_label);
 
+	bt_dev_info(hdev, "QCA FW build version: %s", build_label);
+
 	kfree(build_label);
 out:
 	kfree_skb(skb);


### PR DESCRIPTION
Firmware version is critical for bug triage. Users reporting issues typically share dmesg output rather than debugfs contents, requiring extra communication rounds to collect this information. Log the FW build version directly to the kernel log so it is immediately available in bug reports.

Example output:
Bluetooth: hci0: QCA FW build version: BTFW.MOSELLE.1.1.3-00106-MSL_PATCHZ-1

Acked-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>

Upstream link: https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git/commit/?id=559cab24b04e

CRs-Fixed: 4570456