### PR TITLE
FROMLIST: arm64: dts: qcom: monaco-evk-emmc: Remove explicit UFS disa…

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-emmc.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-emmc.dtso
@@ -35,8 +35,3 @@
 
 	status = "okay";
 };
-
-&vreg_l8a {
-	regulator-min-microvolt = <2960000>;
-	regulator-max-microvolt = <2960000>;
-};


### PR DESCRIPTION
…blement

The eMMC overlay currently explicitly overrides the vreg_l8a voltage to handle the common VDD rail shared between UFS and eMMC. However, their mutual exclusivity is now managed dynamically via DT-fixup logic.

Remove these static entries from the overlay to allow flexible storage configurations.

Link: https://lore.kernel.org/all/20260616130347.3096034-1-monish.chunara@oss.qualcomm.com/

CRs-Fixed: 4569877