### PR TITLE
QCLINUX: arm64: dts: qcom: Enable Glymur camera sensors

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-camera-sensor.dtsi
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <dt-bindings/camera/msm-camera.h>
+
+&cam_cci1 {
+	/*cam0-ov08x*/
+	qcom,cam-sensor0 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <4>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		cam_vio-supply = <&vreg_l4p>;
+		cam_vana-supply = <&vreg_l7p>;
+		regulator-names = "cam_vio", "cam_vana";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000 2800000>;
+		rgltr-max-voltage = <1800000 2800000>;
+		rgltr-load-current = <204000 55000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk4_active &cam_sensor_active_rst4>;
+		pinctrl-1 = <&cam_sensor_mclk4_suspend &cam_sensor_suspend_rst4>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 100 0>,
+			<&tlmm 239 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAM_MCLK4",
+				     "CAMIF_RESET4";
+		cci-master = <1>;
+		clocks = <&camcc CAM_CC_MCLK4_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <0>;
+		status = "okay";
+	};
+};
+
+&soc {
+	qcom,cam-res-mgr {
+		compatible = "qcom,cam-res-mgr";
+		status = "okay";
+	};
+};

--- a/arch/arm64/boot/dts/qcom/glymur-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-camera.dtsi
@@ -1974,7 +1974,7 @@
 					/* IO region is approximately 3.7 GB */
 					iova-region-name = "io";
 					iova-region-start = <0x14c00000>;
-					iova-region-len = <0xee300000>;
+					iova-region-len = <0xeb300000>;
 					iova-region-id = <0x3>;
 					status = "okay";
 				};

--- a/arch/arm64/boot/dts/qcom/glymur-crd-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/glymur-crd-camx.dtso
@@ -19,9 +19,22 @@
 #include <dt-bindings/interconnect/qcom,icc.h>
 
 #include "glymur-camera.dtsi"
+#include "glymur-camera-sensor.dtsi"
 
 &cam_icp_firmware {
 	camera-firmware {
 		iommus = <&apps_smmu 0x1901 0x0000>;
 	};
+};
+
+&camss {
+	status = "disabled";
+};
+
+&cci1 {
+	status = "disabled";
+};
+
+&cci1_i2c1 {
+	status = "disabled";
 };


### PR DESCRIPTION
This change brings below updates:

- Enable camera sensor OV08X on the Glymur CRD platform.
- Fix IOVA region length to ensure 4GB boundary compliance

CRs-Fixed: 4579951
