### PR TITLE
soc: qcom: llcc: Skip ECC interrupt setup on Shikra, pre-configured by DSF

### DIFF
--- a/drivers/soc/qcom/llcc-qcom.c
+++ b/drivers/soc/qcom/llcc-qcom.c
@@ -4325,6 +4325,7 @@ static const struct qcom_llcc_config shikra_cfg[] = {
 		.size		= ARRAY_SIZE(shikra_data),
 		.reg_offset	= llcc_v2_1_reg_offset,
 		.edac_reg_offset = &llcc_v2_1_edac_reg_offset,
+		.irq_configured = true,
 	},
 };
 


### PR DESCRIPTION
On Shikra, the DDR System Firmware (DSF) configures ECC interrupt routing before the kernel driver probes — it enables Tag/Data RAM interrupts and programs error thresholds in the LLCC interrupt-enable registers.

Set irq_configured in shikra_cfg so that qcom_llcc_edac_probe() skips calling qcom_llcc_core_setup(), which would otherwise overwrite the firmware-managed register state with redundant writes.