### PR TITLE
WORKAROUND: arch: arm64: qcom: glymur-crd: Disable PCIe6 instance

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
@@ -511,14 +511,14 @@
 	pinctrl-0 = <&pcie6_default>;
 	pinctrl-names = "default";
 
-	status = "okay";
+	status = "disabled";
 };
 
 &pcie6_phy {
 	vdda-phy-supply = <&vreg_l1c_e1_0p82>;
 	vdda-pll-supply = <&vreg_l4f_e1_1p08>;
 
-	status = "okay";
+	status = "disabled";
 };
 
 &pcie6_port0 {


### PR DESCRIPTION
On compute targets, PCIe is dependent on the UEFI. In UEFI, when a PCIe link-up fails on a given root port, the default behavior is to power down that root port. The power-down sequence disables the PHY, removes all clock votes, and drops the Interconnect Bandwidth (ICB) votes that were applied in UEFI for that PCIe controller.

The HLOS PCIe driver when probes the PCIe6 root port, but probe fails because the PHY is already powered down and there is no PHY bring-up sequence in HLOS for any controller.

Since PCIe probe fails, the Interconnect driver's sync_state callback never gets invoked. As a result, the max boot votes applied to other peripherals are never released or reduced, keeping the system stuck at max bandwidth votes and causing the sync state errors observed, this also blocks XO shutdown.

Fix this temporarly, by disabling pcie6 now as modem is not functional in this release. we will revert this after finding proper fix.