### PR TITLE
arm64: dts: qcom: shikra: align with upstream devicetree submission

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -477,10 +477,6 @@
 	};
 };
 
-&uart0 {
-	status = "okay";
-};
-
 &uart8 {
 	status = "okay";
 
@@ -523,7 +519,7 @@
 	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
 	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
-	firmware-name = "cq2390";
+	firmware-name = "shikra";
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -467,10 +467,6 @@
 
 };
 
-&uart0 {
-	status = "okay";
-};
-
 &uart8 {
 	status = "okay";
 
@@ -529,7 +525,7 @@
 	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
 	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
-	firmware-name = "cq2390";
+	firmware-name = "shikra";
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
@@ -29,11 +29,21 @@
 	status = "okay";
 };
 
-&uart8 {
+&tlmm {
+	sw_ctrl_default: sw-ctrl-default-state {
+		pins = "gpio88";
+		function = "gpio";
+		bias-pull-down;
+	};
+};
 
+&uart0 {
+	status = "okay";
+};
+
+&uart8 {
 	bluetooth {
 		compatible = "qcom,wcn3988-bt";
-
 		max-speed = <3200000>;
 	};
 };

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -419,10 +419,6 @@
 	};
 };
 
-&uart0 {
-	status = "okay";
-};
-
 &uart8 {
 	status = "okay";
 
@@ -474,7 +470,7 @@
 	vdd-1.3-rfa-supply = <&vreg_pmu_rf>;
 	vdd-3.3-ch0-supply = <&vreg_pmu_ch0>;
 	qcom,calibration-variant = "Shikra_EVK";
-	firmware-name = "cq2390";
+	firmware-name = "shikra";
 
 	status = "okay";
 };


### PR DESCRIPTION
Align EVK board files with the latest upstream devicetree submission.

Link: https://lore.kernel.org/all/20260608-shikra-dt-m1-v4-10-2114300594a6@oss.qualcomm.com/