### PR TITLE
platform/arm64: qcom-hamoa-ec: Add hwmon interface for fan PWM control

### DIFF
--- a/drivers/platform/arm64/Kconfig
+++ b/drivers/platform/arm64/Kconfig
@@ -95,11 +95,17 @@ config EC_QCOM_HAMOA
 	depends on ARCH_QCOM || COMPILE_TEST
 	depends on I2C
 	depends on THERMAL || THERMAL=n
+	depends on HWMON || HWMON=n
 	help
 	  Say M or Y here to enable the Embedded Controller driver for Qualcomm
 	  Snapdragon-based Hamoa/Glymur reference devices. The driver handles fan
 	  control, temperature sensors, access to EC state changes and supports
 	  reporting suspend entry/exit to the EC.
+
+	  When HWMON is enabled the driver also exposes fan PWM set-points as
+	  pwm1/pwm2 under /sys/class/hwmon/hwmon*/. Note: the EC firmware does
+	  not provide an RPM read-back command; the pwmN read returns the cached
+	  last-written value.
 
 	  This driver currently supports Hamoa/Purwa/Glymur reference devices.
 

--- a/drivers/platform/arm64/qcom-hamoa-ec.c
+++ b/drivers/platform/arm64/qcom-hamoa-ec.c
@@ -9,6 +9,7 @@
 #include <linux/device.h>
 #include <linux/dev_printk.h>
 #include <linux/err.h>
+#include <linux/hwmon.h>
 #include <linux/i2c.h>
 #include <linux/interrupt.h>
 #include <linux/kernel.h>
@@ -81,6 +82,7 @@ struct qcom_ec {
 	struct qcom_ec_thermal_cap thermal_cap;
 	struct qcom_ec_version version;
 	struct i2c_client *client;
+	struct device *hwmon_dev;
 };
 
 static int qcom_ec_read(struct qcom_ec *ec, u8 cmd, u8 resp_len, u8 *resp)
@@ -326,6 +328,73 @@ static const struct thermal_cooling_device_ops qcom_ec_thermal_ops = {
 	.set_cur_state = qcom_ec_fan_set_cur_state,
 };
 
+static umode_t qcom_ec_hwmon_is_visible(const void *data,
+					enum hwmon_sensor_types type,
+					u32 attr, int channel)
+{
+	const struct qcom_ec *ec = data;
+
+	if (type != hwmon_pwm)
+		return 0;
+	if (channel >= ec->thermal_cap.fan_cnt)
+		return 0;
+
+	switch (attr) {
+	case hwmon_pwm_input:
+		return 0644;
+	default:
+		return 0;
+	}
+}
+
+static int qcom_ec_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
+			      u32 attr, int channel, long *val)
+{
+	struct qcom_ec *ec = dev_get_drvdata(dev);
+
+	if (type != hwmon_pwm || attr != hwmon_pwm_input)
+		return -EOPNOTSUPP;
+	if (channel >= ec->thermal_cap.fan_cnt)
+		return -EINVAL;
+
+	/* Read back the cached PWM value — the EC has no read command. */
+	*val = ec->ec_cdev[channel].state;
+	return 0;
+}
+
+static int qcom_ec_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
+			       u32 attr, int channel, long val)
+{
+	struct qcom_ec *ec = dev_get_drvdata(dev);
+	struct thermal_cooling_device *cdev;
+
+	if (type != hwmon_pwm || attr != hwmon_pwm_input)
+		return -EOPNOTSUPP;
+	if (channel >= ec->thermal_cap.fan_cnt)
+		return -EINVAL;
+
+	val = clamp_val(val, 0, EC_FAN_MAX_PWM);
+	cdev = ec->ec_cdev[channel].cdev;
+
+	return cdev->ops->set_cur_state(cdev, val);
+}
+
+static const struct hwmon_ops qcom_ec_hwmon_ops = {
+	.is_visible = qcom_ec_hwmon_is_visible,
+	.read       = qcom_ec_hwmon_read,
+	.write      = qcom_ec_hwmon_write,
+};
+
+static const struct hwmon_channel_info *qcom_ec_hwmon_info[] = {
+	HWMON_CHANNEL_INFO(pwm, HWMON_PWM_INPUT, HWMON_PWM_INPUT),
+	NULL,
+};
+
+static const struct hwmon_chip_info qcom_ec_hwmon_chip_info = {
+	.ops  = &qcom_ec_hwmon_ops,
+	.info = qcom_ec_hwmon_info,
+};
+
 static int qcom_ec_resume(struct device *dev)
 {
 	struct i2c_client *client = to_i2c_client(dev);
@@ -398,6 +467,18 @@ static int qcom_ec_probe(struct i2c_client *client)
 					     "Failed to register fan%d cooling device\n", i);
 		}
 	}
+
+	/*
+	 * Register hwmon device exposing fan PWM set-points as pwm1/pwm2.
+	 * The EC has no RPM read command; the hwmon read returns the cached
+	 * last-written PWM value. Only as many channels as fans are active.
+	 */
+	ec->hwmon_dev = devm_hwmon_device_register_with_info(dev, "qcom_ec", ec,
+							     &qcom_ec_hwmon_chip_info,
+							     NULL);
+	if (IS_ERR(ec->hwmon_dev))
+		return dev_err_probe(dev, PTR_ERR(ec->hwmon_dev),
+				     "Failed to register hwmon device\n");
 
 	return 0;
 }


### PR DESCRIPTION
Expose the EC's fan PWM set-points as a standard hwmon device (qcom_ec / hwmon_pwm), providing pwm1 and pwm2 channels under /sys/class/hwmon/hwmon*/pwmN.