### PR TITLE
PENDING: arm64: dts: qcom: kaanapali: add Coresight devices for APSS debug block

### DIFF
--- a/arch/arm64/boot/dts/qcom/kaanapali-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/kaanapali-staging.dtso
@@ -8,6 +8,120 @@
 /dts-v1/;
 /plugin/;
 
+&{/} {
+	ete-0 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu0>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm0_out: endpoint {
+					remote-endpoint = <&ncc0_0_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-1 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu1>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm1_out: endpoint {
+					remote-endpoint = <&ncc0_1_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-2 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu2>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm2_out: endpoint {
+					remote-endpoint = <&ncc0_2_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-3 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu3>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm3_out: endpoint {
+					remote-endpoint = <&ncc0_3_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-4 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu4>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm4_out: endpoint {
+					remote-endpoint = <&ncc0_4_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-5 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu5>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm5_out: endpoint {
+					remote-endpoint = <&ncc0_5_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-6 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu6>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm6_out: endpoint {
+					remote-endpoint = <&ncc1_0_rep_in>;
+				};
+			};
+		};
+	};
+
+	ete-7 {
+		compatible = "arm,embedded-trace-extension";
+		cpu = <&cpu7>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm7_out: endpoint {
+					remote-endpoint = <&ncc1_1_rep_in>;
+				};
+			};
+		};
+	};
+};
+
 &soc {
 	ctcu: ctcu@10001000 {
 		compatible = "qcom,sa8775p-ctcu";
@@ -197,14 +311,6 @@
 					remote-endpoint = <&replicator_qdss_in>;
 				};
 			};
-
-			port@1 {
-				reg = <1>;
-
-				replicator_swao_out1: endpoint {
-					remote-endpoint = <&eud_in>;
-				};
-			};
 		};
 	};
 
@@ -230,5 +336,503 @@
 
 		clocks = <&aoss_qmp>;
 		clock-names = "apb_pclk";
+	};
+
+	replicator@1d090000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d090000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_0_rep_in: endpoint {
+					remote-endpoint = <&etm0_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_0_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	replicator@1d0a0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d0a0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_1_rep_in: endpoint {
+					remote-endpoint = <&etm1_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_1_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in1>;
+				};
+			};
+		};
+	};
+
+	replicator@1d0b0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d0b0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_2_rep_in: endpoint {
+					remote-endpoint = <&etm2_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_2_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	replicator@1d0c0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d0c0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_3_rep_in: endpoint {
+					remote-endpoint = <&etm3_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_3_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in3>;
+				};
+			};
+		};
+	};
+
+	replicator@1d0d0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d0d0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_4_rep_in: endpoint {
+					remote-endpoint = <&etm4_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_4_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in4>;
+				};
+			};
+		};
+	};
+
+	replicator@1d0e0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d0e0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_5_rep_in: endpoint {
+					remote-endpoint = <&etm5_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_5_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in5>;
+				};
+			};
+		};
+	};
+
+	funnel@1d081000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x1d081000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				ncc0_1_funnel_in0: endpoint {
+					remote-endpoint = <&ncc0_0_rep_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				ncc0_1_funnel_in1: endpoint {
+					remote-endpoint = <&ncc0_1_rep_out>;
+				};
+			};
+
+			port@2 {
+				reg = <2>;
+
+				ncc0_1_funnel_in2: endpoint {
+					remote-endpoint = <&ncc0_2_rep_out>;
+				};
+			};
+
+			port@3 {
+				reg = <3>;
+
+				ncc0_1_funnel_in3: endpoint {
+					remote-endpoint = <&ncc0_3_rep_out>;
+				};
+			};
+
+			port@4 {
+				reg = <4>;
+
+				ncc0_1_funnel_in4: endpoint {
+					remote-endpoint = <&ncc0_4_rep_out>;
+				};
+			};
+
+			port@5 {
+				reg = <5>;
+
+				ncc0_1_funnel_in5: endpoint {
+					remote-endpoint = <&ncc0_5_rep_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_1_funnel_out: endpoint {
+					remote-endpoint = <&ncc0_2_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	funnel@1d021000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x1d021000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@2 {
+				reg = <2>;
+
+				ncc0_2_funnel_in2: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_2_funnel_out: endpoint {
+					remote-endpoint = <&ncc0_etf_in>;
+				};
+			};
+		};
+	};
+
+	tmc@1d029000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb961>;
+		reg = <0x0 0x1d029000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_etf_in: endpoint {
+					remote-endpoint = <&ncc0_2_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_etf_out: endpoint {
+					remote-endpoint = <&apss_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	replicator@1d190000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d190000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_0_rep_in: endpoint {
+					remote-endpoint = <&etm6_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_0_rep_out: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	replicator@1d1a0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x1d1a0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_1_rep_in: endpoint {
+					remote-endpoint = <&etm7_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_1_rep_out: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_in1>;
+				};
+			};
+		};
+	};
+
+	funnel@1d181000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x1d181000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				ncc1_1_funnel_in0: endpoint {
+					remote-endpoint = <&ncc1_0_rep_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				ncc1_1_funnel_in1: endpoint {
+					remote-endpoint = <&ncc1_1_rep_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_1_funnel_out: endpoint {
+					remote-endpoint = <&ncc1_2_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	funnel@1d121000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x1d121000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@2 {
+				reg = <2>;
+
+				ncc1_2_funnel_in2: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_2_funnel_out: endpoint {
+					remote-endpoint = <&ncc1_etf_in>;
+				};
+			};
+		};
+	};
+
+	tmc@1d129000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb961>;
+		reg = <0x0 0x1d129000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_etf_in: endpoint {
+					remote-endpoint = <&ncc1_2_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_etf_out: endpoint {
+					remote-endpoint = <&apss_funnel_in1>;
+				};
+			};
+		};
+	};
+
+	apss_funnel: funnel@12080000 {
+		compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
+		reg = <0x0 0x12080000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				apss_funnel_in0: endpoint {
+					remote-endpoint = <&ncc0_etf_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				apss_funnel_in1: endpoint {
+					remote-endpoint = <&ncc1_etf_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				apss_funnel_out: endpoint {
+					remote-endpoint = <&tn_ag_in54>;
+				};
+			};
+		};
+	};
+
+	tn@111b8000 {
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@36 {
+				reg = <0x36>;
+
+				tn_ag_in54: endpoint {
+					remote-endpoint = <&apss_funnel_out>;
+				};
+			};
+		};
 	};
 };


### PR DESCRIPTION
Add the following devices that are part of the APSS debug block to enable debug features, including ETM, replicator, funnel, and TMC ETF.