### PR TITLE
remoteproc: qcom: pas: Enable auto-boot for Shikra CDSP

### DIFF
--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -1462,7 +1462,7 @@ static const struct qcom_pas_data shikra_cdsp_resource = {
 	.firmware_name = "cdsp.mbn",
 	.pas_id = 18,
 	.minidump_id = 7,
-	.auto_boot = false,
+	.auto_boot = true,
 	.proxy_pd_names = (char *[]){
 		"cx",
 		NULL


### PR DESCRIPTION
Set auto_boot to true for the Shikra CDSP Peripheral Authentication Service so the CDSP is brought up automatically during boot rather than requiring an explicit start from userspace.


CRs-Fixed: 4581499

