### PR TITLE
QCLINUX: arm64: dts: qcom: hamoa: Add PM8010_M camera regulator dtsi

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-camera-regulators.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa-camera-regulators.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
+
+&apps_rsc {
+	/* PM8010_M */
+	regulators-8 {
+		compatible = "qcom,pm8010-rpmh-regulators";
+		qcom,pmic-id = "m";
+
+		vdd-l1-l2-supply = <&vreg_s5j_1p2>;
+		vdd-l3-l4-supply = <&vreg_s4c_1p8>;
+		vdd-l5-supply = <&vreg_bob1>;
+		vdd-l6-supply = <&vreg_s4c_1p8>;
+		vdd-l7-supply = <&vreg_bob1>;
+
+		vreg_l1m_1p1: ldo1 {
+			regulator-name = "vreg_l1m_1p1";
+			regulator-min-microvolt = <1056000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l2m_1p15: ldo2 {
+			regulator-name = "vreg_l2m_1p15";
+			regulator-min-microvolt = <1152000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l3m_1p8: ldo3 {
+			regulator-name = "vreg_l3m_1p8";
+			regulator-min-microvolt = <1808000>;
+			regulator-max-microvolt = <1808000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l4m_1p8: ldo4 {
+			regulator-name = "vreg_l4m_1p8";
+			regulator-min-microvolt = <1808000>;
+			regulator-max-microvolt = <1808000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l5m_3p0: ldo5 {
+			regulator-name = "vreg_l5m_3p0";
+			regulator-min-microvolt = <2960000>;
+			regulator-max-microvolt = <2960000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l6m_1p8: ldo6 {
+			regulator-name = "vreg_l6m_1p8";
+			regulator-min-microvolt = <1808000>;
+			regulator-max-microvolt = <1808000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l7m_2p9: ldo7 {
+			regulator-name = "vreg_l7m_2p9";
+			regulator-min-microvolt = <2912000>;
+			regulator-max-microvolt = <2912000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtso
@@ -18,6 +18,7 @@
 #include <dt-bindings/power/qcom-rpmpd.h>
 #include <dt-bindings/interconnect/qcom,icc.h>
 
+#include "hamoa-camera-regulators.dtsi"
 #include "hamoa-camera.dtsi"
 #include "hamoa-camera-sensor.dtsi"
 

--- a/arch/arm64/boot/dts/qcom/purwa-evk-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/purwa-evk-camx.dtso
@@ -18,6 +18,7 @@
 #include <dt-bindings/power/qcom-rpmpd.h>
 #include <dt-bindings/interconnect/qcom,icc.h>
 
+#include "hamoa-camera-regulators.dtsi"
 #include "purwa-camera.dtsi"
 
 &camss {


### PR DESCRIPTION
Add hamoa-camera-regulators.dtsi to define the PM8010_M PMIC LDO regulators needed by camera sensor drivers, and include it in both hamoa-evk-camx.dtso and purwa-evk-camx.dtso.

L1M supplies the IMX688 AON core domain (DVDD). It is fed by S5J and supports an output range of 1056-1200 mV.

L2M supplies the IMX766 core domain (DVDD). It is fed by S5J and supports an output range of 1152-1200 mV.

L3M supplies the IMX766 analog domain and OV sensor I/O (AVDD2, DOVDD). It is fed by S4C and is fixed at 1808 mV.

L4M supplies the IMX688 AON I/O domain and IMX766 I/O domain (DOVDD). It is fed by S4C and is fixed at 1808 mV.

L5M supplies the IMX766 VCM. It is fed by BOB1 and is fixed at 2960 mV.

L6M supplies the IMX688 AON analog domain (AVDD2). It is fed by S4C and is fixed at 1808 mV.

L7M supplies the camera analog domain (AVDD). It is fed by BOB1 and is fixed at 2912 mV.