### PR TITLE
arm64: dts: qcom: shikra-iqs-evk: Remove GPIO138 from reserved ranges

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -320,7 +320,7 @@
 };
 
 &tlmm {
-	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <155 11>;
 
 	dmic01_default: dmic01-default-state {
 		clk-pins {


### PR DESCRIPTION
GPIO138 is used for RGMII1_RX_CTL on the second EMAC interface of the IQS EVK board. Having it listed in gpio-reserved-ranges causes the pinctrl subsystem to reject the pin configuration during Ethernet probe,preventing the EMAC from initializing.

Remove GPIO138 from the reserved range so that the EMAC pinctrl state can be applied successfully.

CRs-Fixed: 4582518