### PR TITLE
prune.config: Enable the TI DP83867 PHY driver

### DIFF
--- a/arch/arm64/configs/prune.config
+++ b/arch/arm64/configs/prune.config
@@ -93,7 +93,6 @@
 # CONFIG_BCM54140_PHY is not set
 # CONFIG_MICROSEMI_PHY is not set
 # CONFIG_ROCKCHIP_PHY is not set
-# CONFIG_DP83867_PHY is not set
 # CONFIG_DP83TD510_PHY is not set
 # CONFIG_VITESSE_PHY is not set
 # CONFIG_CAN_FLEXCAN is not set


### PR DESCRIPTION
The Shikra EVK boards have an RGMII TI PHY connected to the dual EMACs of the SoC. Remove its config from prune.config to enable its driver.

CRs-Fixed: 4582518