### PR TITLE
arm64: dts: qcom: shikra: update mpss firmware-name paths for EVK var…

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -295,7 +295,7 @@
 };
 
 &remoteproc_mpss {
-	firmware-name = "qcom/shikra/qdsp6sw.mbn";
+	firmware-name = "qcom/shikra/cqm/qdsp6sw.mbn";
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -270,7 +270,7 @@
 };
 
 &remoteproc_mpss {
-        firmware-name = "qcom/shikra/qdsp6sw.mbn";
+        firmware-name = "qcom/shikra/cqs/qdsp6sw.mbn";
 
         status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -282,7 +282,7 @@
 };
 
 &remoteproc_mpss {
-        firmware-name = "qcom/shikra/qdsp6sw.mbn";
+        firmware-name = "qcom/shikra/cqs/qdsp6sw.mbn";
 
         status = "okay";
 };


### PR DESCRIPTION
…iants

Update the remoteproc_mpss firmware-name to use board-variant-specific paths for CQM, CQS and IQS EVK boards.