### PR TITLE
FROMLIST: arm64: dts: qcom: kaanapali: fix traceNoC probe issue

### DIFF
--- a/arch/arm64/boot/dts/qcom/kaanapali.dtsi
+++ b/arch/arm64/boot/dts/qcom/kaanapali.dtsi
@@ -5772,12 +5772,12 @@
 			};
 		};
 
-		tn@111b8000 {
-			compatible = "qcom,coresight-tnoc", "arm,primecell";
+		itnoc@111b8000 {
+			compatible = "qcom,coresight-itnoc";
 			reg = <0x0 0x111b8000 0x0 0x4200>;
 
 			clocks = <&aoss_qmp>;
-			clock-names = "apb_pclk";
+			clock-names = "apb";
 
 			in-ports {
 				#address-cells = <1>;


### PR DESCRIPTION
Fix probing of the traceNoC device by switching from the AMBA bus to the platform itnoc driver.

Link: https://lore.kernel.org/r/20260624-fix-tracenoc-probe-issue-v1-1-bcc785198fc5@oss.qualcomm.com
Fixes: f73959d86c15 ("arm64: dts: qcom: kaanapali: add coresight nodes")