### PR TITLE
arm64: dts: qcom: lemans-evk: Enable WCN6855 BT via PCIe M.2 Key E connector

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -139,6 +139,38 @@
 		};
 	};
 
+	connector-3 {
+		compatible = "pcie-m2-e-connector";
+		vpcie3v3-supply = <&vreg_wcn_3p3>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				m2_e_pcie_ep: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&pcieport0_ep>;
+				};
+			};
+
+			port@3 {
+				reg = <3>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				m2_e_uart_ep: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&uart17_ep>;
+				};
+			};
+		};
+	};
+
 	edp0-connector {
 		compatible = "dp-connector";
 		label = "EDP0";
@@ -270,8 +302,8 @@
 		regulator-min-microvolt = <12000000>;
 		regulator-max-microvolt = <12000000>;
 
-		regulator-boot-on;
 		regulator-always-on;
+		regulator-boot-on;
 	};
 
 	vreg_sdc: regulator-vreg-sdc {
@@ -297,6 +329,7 @@
 
 		vin-supply = <&vreg_dcin_12v>;
 
+		regulator-always-on;
 		regulator-boot-on;
 	};
 };
@@ -878,6 +911,14 @@
 	status = "okay";
 };
 
+&pcieport0 {
+	port {
+		pcieport0_ep: endpoint {
+			remote-endpoint = <&m2_e_pcie_ep>;
+		};
+	};
+};
+
 &pmm8654au_0_pon_resin {
 	linux,code = <KEY_VOLUMEDOWN>;
 	status = "okay";
@@ -1116,18 +1157,10 @@
 &uart17 {
 	status = "okay";
 
-	bluetooth: bluetooth {
-		compatible = "qcom,wcn6855-bt";
-		max-speed = <3200000>;
-
-		vddrfacmn-supply = <&vreg_wcn_3p3>;
-		vddaon-supply = <&vreg_wcn_3p3>;
-		vddwlcx-supply = <&vreg_wcn_3p3>;
-		vddwlmx-supply = <&vreg_wcn_3p3>;
-		vddbtcmx-supply = <&vreg_wcn_3p3>;
-		vddrfa0p8-supply = <&vreg_wcn_3p3>;
-		vddrfa1p2-supply = <&vreg_wcn_3p3>;
-		vddrfa1p8-supply = <&vreg_wcn_3p3>;
+	port {
+		uart17_ep: endpoint {
+			remote-endpoint = <&m2_e_uart_ep>;
+		};
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -9120,6 +9120,7 @@
 		status = "disabled";
 
 		pcieport0: pcie@0 {
+			compatible = "pciclass,0604";
 			device_type = "pci";
 			reg = <0x0 0x0 0x0 0x0 0x0>;
 			bus-range = <0x01 0xff>;


### PR DESCRIPTION
This series enables the WCN6855 Bluetooth/WLAN module on the lemans EVK
via the PCIe M.2 Key E connector.

Patch 1 adds the PCI-to-PCI bridge compatible to the lemans pcieport0
Root Port in the SoC dtsi, required for downstream M.2 connector graph
endpoints to be matched to PCI devices.

Patch 2 describes the M.2 Key E connector on lemans-evk and links it
with PCIe RP0 and UART17 via graph ports/endpoints.

Upstream: https://lore.kernel.org/all/20260622-v3-lemans-split-v3-0-d26bb22594e3@oss.qualcomm.com/

CRs-Fixed: 4550026