### PR TITLE
WORKAROUND: misc: fastrpc: use dev_dbg for absent remote heap memory

### DIFF
--- a/drivers/misc/fastrpc.c
+++ b/drivers/misc/fastrpc.c
@@ -1492,7 +1492,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
 	if (!cctx->remote_heap || !cctx->remote_heap->dma_addr ||
 	    !cctx->remote_heap->size) {
 		err = -ENOMEM;
-		dev_err(fl->sctx->dev,
+		dev_dbg(fl->sctx->dev,
 			"remote heap memory region is not added\n");
 		return err;
 	}


### PR DESCRIPTION
On platforms where remote heap memory is not present, dev_err() can flood the kernel log. Use dev_dbg() instead to reduce log verbosity in this expected condition.