### PR TITLE
FROMLIST: arm64: dts: qcom: qcm6490-idp: add and enable IPA node

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
@@ -614,6 +614,13 @@
 	firmware-name = "qcom/qcm6490/a660_zap.mbn";
 };
 
+&ipa {
+	qcom,gsi-loader = "self";
+	memory-region = <&ipa_fw_mem>;
+	firmware-name = "qcom/qcm6490/ipa_fws.mbn";
+	status = "okay";
+};
+
 &lpass_rx_macro {
 	status = "okay";
 };


### PR DESCRIPTION
Enable IPA and ensure ipa apps loads the gsi firmware because modem doesn't support IPA FW loading.

Link: https://lore.kernel.org/all/20260618124700.2001191-1-sarat.addepalli@oss.qualcomm.com/

CRs-Fixed: 4576442