### PR TITLE
WORKAROUND: Gdsc synced poweroff disable patches for QCS615

### DIFF
--- a/drivers/clk/qcom/gcc-qcs615.c
+++ b/drivers/clk/qcom/gcc-qcs615.c
@@ -2675,6 +2675,7 @@ static struct gdsc usb20_sec_gdsc = {
 	.clk_dis_wait_val = 0x2,
 	.pd = {
 		.name = "usb20_sec_gdsc",
+		.power_off = gdsc_synced_poweroff_disable,
 	},
 	.pwrsts = PWRSTS_OFF_ON,
 };
@@ -2686,6 +2687,7 @@ static struct gdsc usb30_prim_gdsc = {
 	.clk_dis_wait_val = 0x2,
 	.pd = {
 		.name = "usb30_prim_gdsc",
+		.power_off = gdsc_synced_poweroff_disable,
 	},
 	.pwrsts = PWRSTS_OFF_ON,
 };

--- a/drivers/clk/qcom/gdsc.h
+++ b/drivers/clk/qcom/gdsc.h
@@ -89,6 +89,7 @@ int gdsc_register(struct gdsc_desc *desc, struct reset_controller_dev *,
 void gdsc_unregister(struct gdsc_desc *desc);
 int gdsc_gx_do_nothing_enable(struct generic_pm_domain *domain);
 int gdsc_gx_disable(struct generic_pm_domain *domain);
+#define gdsc_synced_poweroff_disable gdsc_gx_disable
 #else
 static inline int gdsc_register(struct gdsc_desc *desc,
 				struct reset_controller_dev *rcdev,

--- a/drivers/usb/dwc3/dwc3-qcom.c
+++ b/drivers/usb/dwc3/dwc3-qcom.c
@@ -18,6 +18,7 @@
 #include <linux/reset.h>
 #include <linux/iopoll.h>
 #include <linux/usb/hcd.h>
+#include <linux/pm_domain.h>
 #include <linux/usb.h>
 #include "core.h"
 #include "glue.h"
@@ -362,6 +363,8 @@ static int dwc3_qcom_suspend(struct dwc3_qcom *qcom, bool wakeup)
 		for (i = 0; i < qcom->num_ports; i++)
 			qcom->ports[i].usb2_speed = dwc3_qcom_read_usb2_speed(qcom, i);
 		dwc3_qcom_enable_interrupts(qcom);
+	} else {
+		dev_pm_genpd_synced_poweroff(qcom->dev);
 	}
 
 	qcom->is_suspended = true;


### PR DESCRIPTION
Add support to keep GDSC On during host mode bus suspend

On targets pre-sm8750, when DUT enters bus suspend in host mode, there is     a xHCI crash seen on resume. During bus susend use case if the device is  wakeup capable, the GDSC needs to be kept ON to retain memory and avoid  SMMU faults. Set synced_poweroff flag to false to ensure GDSC is turned  OFF during cable disconnect or non-bus suspend host mode scenario.

Use gdsc_synced_poweroff_disable callback for USB GDSC's on qcs615 platforms so these GDSC's get disabled only when consumer drivers explicitly invoke dev_pm_genpd_synced_poweroff() API before suspend.

CRs-Fixed: 4492412