### PR TITLE
swiotlb: introduce Kconfig option for compile-time default pool size

### DIFF
--- a/include/linux/swiotlb.h
+++ b/include/linux/swiotlb.h
@@ -32,8 +32,12 @@ struct scatterlist;
 #define IO_TLB_SHIFT 11
 #define IO_TLB_SIZE (1 << IO_TLB_SHIFT)
 
-/* default to 64MB */
-#define IO_TLB_DEFAULT_SIZE (64UL<<20)
+/* compile-time default; overridable via CONFIG_SWIOTLB_DEFAULT_SIZE_MB */
+#ifdef CONFIG_SWIOTLB
+#define IO_TLB_DEFAULT_SIZE ((unsigned long)CONFIG_SWIOTLB_DEFAULT_SIZE_MB << 20)
+#else
+#define IO_TLB_DEFAULT_SIZE (64UL << 20)
+#endif
 
 unsigned long swiotlb_size_or_default(void);
 void __init swiotlb_init_remap(bool addressing_limit, unsigned int flags,

--- a/kernel/dma/Kconfig
+++ b/kernel/dma/Kconfig
@@ -83,6 +83,28 @@ config SWIOTLB
 	bool
 	select NEED_DMA_MAP_STATE
 
+config SWIOTLB_DEFAULT_SIZE_MB
+	int "Default SWIOTLB bounce buffer size in MB"
+	depends on SWIOTLB
+	range 1 64
+	default 64
+	help
+	  Sets the default size of the software IO TLB (SWIOTLB) bounce buffer
+	  pool allocated at boot time. The default is 64 MB.
+
+	  On memory-constrained embedded or mobile platforms (e.g., those with
+	  a hardware IOMMU such as ARM SMMU covering most DMA-capable devices),
+	  a smaller value such as 4 or 8 MB may be sufficient. The SWIOTLB is
+	  then only needed for devices that bypass the IOMMU or have restricted
+	  DMA address ranges.
+
+	  The minimum allowed value is 1 MB. This compile-time default can be
+	  overridden at runtime using the "swiotlb=<nslabs>" kernel command line
+	  parameter. Refer to Documentation/admin-guide/kernel-parameters.txt
+	  for details.
+
+	  If unsure, leave at the default value of 64.
+
 config SWIOTLB_DYNAMIC
 	bool "Dynamic allocation of DMA bounce buffers"
 	default n


### PR DESCRIPTION
The SWIOTLB bounce buffer pool size is hardcoded at 64 MB via IO_TLB_DEFAULT_SIZE with no compile-time knob to adjust it. On memory-constrained embedded or mobile platforms equipped with a hardware IOMMU (e.g., ARM SMMU) covering most DMA-capable devices, reserving 64 MB at boot is unnecessarily wasteful — the SWIOTLB is only exercised for devices that bypass the IOMMU or have restricted DMA address ranges.

Introduce CONFIG_SWIOTLB_DEFAULT_SIZE_MB, an integer Kconfig option (range 1–64 MB, default 64) that allows platforms to set a smaller compile-time default. IO_TLB_DEFAULT_SIZE is updated to derive from this value when CONFIG_SWIOTLB is enabled, preserving the existing 64 MB default when the option is not configured.

The runtime "swiotlb=<nslabs>" kernel parameter override remains fully supported and takes precedence over the compile-time default.

Link: https://lore.kernel.org/all/20260617-swiotlb-v1-1-abfee3faf4ea@oss.qualcomm.com/

CRs-Fixed: 4490764