### PR TITLE
FROMLIST: arm64: dts: qcom: purwa-evk: add DP0/DP1 audio playback support

### DIFF
--- a/arch/arm64/boot/dts/qcom/purwa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/purwa-iot-evk.dts
@@ -616,6 +616,38 @@
 				sound-dai = <&q6apm>;
 			};
 		};
+
+		dp0-dai-link {
+			link-name = "DP0 Playback";
+
+			codec {
+				sound-dai = <&mdss_dp0>;
+			};
+
+			cpu {
+				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
+
+		dp1-dai-link {
+			link-name = "DP1 Playback";
+
+			codec {
+				sound-dai = <&mdss_dp1>;
+			};
+
+			cpu {
+				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_1>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
 	};
 
 	wcn7850-pmu {


### PR DESCRIPTION
The purwa-evk DTS currently lacks DAI links for DP0 and DP1, preventing the sound card from exposing these playback paths. Add the missing links to enable audio output on both DP interfaces.

Link: https://lore.kernel.org/all/20260701063003.3082899-1-le.qi@oss.qualcomm.com/

CRs-Fixed: 4619462