### PR TITLE
PENDING: arm64: dts: qcom: sm8750: add Coresight devices for APSS debug block

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8750-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/sm8750-staging.dtso
@@ -8,7 +8,160 @@
 /dts-v1/;
 /plugin/;
 
+&{/} {
+	etm-0 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu0>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm0_out: endpoint {
+					remote-endpoint = <&ncc0_0_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-1 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu1>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm1_out: endpoint {
+					remote-endpoint = <&ncc0_1_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-2 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu2>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm2_out: endpoint {
+					remote-endpoint = <&ncc0_2_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-3 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu3>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm3_out: endpoint {
+					remote-endpoint = <&ncc0_3_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-4 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu4>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm4_out: endpoint {
+					remote-endpoint = <&ncc0_4_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-5 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu5>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm5_out: endpoint {
+					remote-endpoint = <&ncc0_5_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-6 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu6>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm6_out: endpoint {
+					remote-endpoint = <&ncc1_0_rep_in>;
+				};
+			};
+		};
+	};
+
+	etm-7 {
+		compatible = "arm,coresight-etm4x-sysreg";
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		cpu = <&cpu7>;
+		qcom,skip-power-up;
+
+		out-ports {
+			port {
+				etm7_out: endpoint {
+					remote-endpoint = <&ncc1_1_rep_in>;
+				};
+			};
+		};
+	};
+};
+
 &soc {
+	tn@109ab000 {
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@21 {
+				reg = <0x21>;
+
+				tn_ag_in33: endpoint {
+					remote-endpoint = <&apss_funnel_out>;
+				};
+			};
+		};
+	};
+
 	tgu@10b0e000 {
 		compatible = "qcom,tgu", "arm,primecell";
 		reg = <0x0 0x10b0e000 0x0 0x1000>;
@@ -31,5 +184,488 @@
 
 		clocks = <&aoss_qmp>;
 		clock-names = "apb_pclk";
+	};
+
+	apss_funnel: funnel@12080000 {
+		compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
+		reg = <0x0 0x12080000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				apss_funnel_in0: endpoint {
+					remote-endpoint = <&ncc0_etf_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				apss_funnel_in1: endpoint {
+					remote-endpoint = <&ncc1_etf_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				apss_funnel_out: endpoint {
+					remote-endpoint = <&tn_ag_in33>;
+				};
+			};
+		};
+	};
+
+	funnel@13401000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x13401000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@2 {
+				reg = <2>;
+
+				ncc0_2_funnel_in2: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_2_funnel_out: endpoint {
+					remote-endpoint = <&ncc0_etf_in>;
+				};
+			};
+		};
+	};
+
+	tmc@13409000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb961>;
+		reg = <0x0 0x13409000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_etf_in: endpoint {
+					remote-endpoint = <&ncc0_2_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_etf_out: endpoint {
+					remote-endpoint = <&apss_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	funnel@13481000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x13481000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				ncc0_1_funnel_in0: endpoint {
+					remote-endpoint = <&ncc0_0_rep_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				ncc0_1_funnel_in1: endpoint {
+					remote-endpoint = <&ncc0_1_rep_out>;
+				};
+			};
+
+			port@2 {
+				reg = <2>;
+
+				ncc0_1_funnel_in2: endpoint {
+					remote-endpoint = <&ncc0_2_rep_out>;
+				};
+			};
+
+			port@3 {
+				reg = <3>;
+
+				ncc0_1_funnel_in3: endpoint {
+					remote-endpoint = <&ncc0_3_rep_out>;
+				};
+			};
+
+			port@4 {
+				reg = <4>;
+
+				ncc0_1_funnel_in4: endpoint {
+					remote-endpoint = <&ncc0_4_rep_out>;
+				};
+			};
+
+			port@5 {
+				reg = <5>;
+
+				ncc0_1_funnel_in5: endpoint {
+					remote-endpoint = <&ncc0_5_rep_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_1_funnel_out: endpoint {
+					remote-endpoint = <&ncc0_2_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	replicator@13490000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x13490000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_0_rep_in: endpoint {
+					remote-endpoint = <&etm0_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_0_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	replicator@134a0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x134a0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_1_rep_in: endpoint {
+					remote-endpoint = <&etm1_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_1_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in1>;
+				};
+			};
+		};
+	};
+
+	replicator@134b0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x134b0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_2_rep_in: endpoint {
+					remote-endpoint = <&etm2_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_2_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	replicator@134c0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x134c0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_3_rep_in: endpoint {
+					remote-endpoint = <&etm3_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_3_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in3>;
+				};
+			};
+		};
+	};
+
+	replicator@134d0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x134d0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_4_rep_in: endpoint {
+					remote-endpoint = <&etm4_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_4_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in4>;
+				};
+			};
+		};
+	};
+
+	replicator@134e0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x134e0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster0_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc0_5_rep_in: endpoint {
+					remote-endpoint = <&etm5_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc0_5_rep_out: endpoint {
+					remote-endpoint = <&ncc0_1_funnel_in5>;
+				};
+			};
+		};
+	};
+
+	funnel@13d01000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x13d01000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster1_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@2 {
+				reg = <2>;
+
+				ncc1_2_funnel_in2: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_2_funnel_out: endpoint {
+					remote-endpoint = <&ncc1_etf_in>;
+				};
+			};
+		};
+	};
+
+	tmc@13d09000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb961>;
+		reg = <0x0 0x13d09000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster1_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_etf_in: endpoint {
+					remote-endpoint = <&ncc1_2_funnel_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_etf_out: endpoint {
+					remote-endpoint = <&apss_funnel_in1>;
+				};
+			};
+		};
+	};
+
+	funnel@13d81000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb908>;
+		reg = <0x0 0x13d81000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster1_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				ncc1_1_funnel_in0: endpoint {
+					remote-endpoint = <&ncc1_0_rep_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				ncc1_1_funnel_in1: endpoint {
+					remote-endpoint = <&ncc1_1_rep_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_1_funnel_out: endpoint {
+					remote-endpoint = <&ncc1_2_funnel_in2>;
+				};
+			};
+		};
+	};
+
+	replicator@13d90000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x13d90000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster1_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_0_rep_in: endpoint {
+					remote-endpoint = <&etm6_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_0_rep_out: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_in0>;
+				};
+			};
+		};
+	};
+
+	replicator@13da0000 {
+		compatible = "arm,primecell";
+		arm,primecell-periphid = <0x000bb909>;
+		reg = <0x0 0x13da0000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+		power-domains = <&cluster1_pd>;
+		qcom,cpu-bound-components;
+
+		in-ports {
+			port {
+				ncc1_1_rep_in: endpoint {
+					remote-endpoint = <&etm7_out>;
+				};
+			};
+		};
+
+		out-ports {
+			port {
+				ncc1_1_rep_out: endpoint {
+					remote-endpoint = <&ncc1_1_funnel_in1>;
+				};
+			};
+		};
 	};
 };


### PR DESCRIPTION
Add the following devices that are part of the APSS debug block to enable debug features, including ETM, replicator, funnel, and TMC ETF.