### PR TITLE
QCLINUX: arm64: dts: qcom: Removed Imx577 sensor && Swap RESET and POWER down pins

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-camera-sensor.dtsi
@@ -400,46 +400,6 @@
 	};
 
 	/*cam0-imx577*/
-	qcom,cam-sensor19 {
-		compatible = "qcom,cam-sensor";
-		cell-index = <19>;
-		csiphy-sd-index = <1>;
-		sensor-position-roll = <0>;
-		sensor-position-pitch = <0>;
-		sensor-position-yaw = <180>;
-		eeprom-src = <&eeprom_cam19>;
-		regulator-names = "cam_vio";
-		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		rgltr-cntrl-support;
-		pwm-switch;
-		rgltr-min-voltage = <1800000>;
-		rgltr-max-voltage = <1800000>;
-		rgltr-load-current = <120000>;
-		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-			     &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-			     &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 68 0>,
-			<&tlmm 74 0>,
-			<&expander2 1 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK1",
-				     "CAMIF_RESET1",
-				     "CAM_CUSTOM1";
-		cci-master = <0>;
-		clocks = <&camcc CAM_CC_MCLK1_CLK>;
-		clock-names = "cam_clk";
-		clock-cntl-level = "nominal";
-		clock-rates = <24000000>;
-		status = "ok";
-	};
-
-	/*cam0-imx577*/
 	qcom,cam-sensor21 {
 		compatible = "qcom,cam-sensor";
 		cell-index = <21>;
@@ -471,41 +431,6 @@
 		gpio-req-tbl-label = "CAM_MCLK1",
 				     "CAMIF_RESET1",
 				     "CAM_CUSTOM1";
-		cci-master = <0>;
-		clocks = <&camcc CAM_CC_MCLK1_CLK>;
-		clock-names = "cam_clk";
-		clock-cntl-level = "nominal";
-		clock-rates = <24000000>;
-		status = "ok";
-	};
-
-	eeprom_cam19: qcom,eeprom19 {
-		compatible = "qcom,eeprom";
-		cell-index = <19>;
-		regulator-names = "cam_vio";
-		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		rgltr-cntrl-support;
-		pwm-switch;
-		rgltr-min-voltage = <1800000>;
-		rgltr-max-voltage = <1800000>;
-		rgltr-load-current = <120000>;
-		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk1_active
-			     &cam_sensor_active_rst1>;
-		pinctrl-1 = <&cam_sensor_mclk1_suspend
-			     &cam_sensor_suspend_rst1>;
-		pinctrl-names = "cam_default", "cam_suspend";
-		gpios = <&tlmm 68 0>,
-			<&tlmm 74 0>,
-			<&expander2 1 0>;
-		gpio-reset = <1>;
-		gpio-custom1 = <2>;
-		gpio-req-tbl-num = <0 1 2>;
-		gpio-req-tbl-flags = <1 0 0>;
-		gpio-req-tbl-label = "CAM_MCLK1",
-				     "CAMIF_RESET1",
-				     "CAM_CUSTOM1";
-		sensor-mode = <0>;
 		cci-master = <0>;
 		clocks = <&camcc CAM_CC_MCLK1_CLK>;
 		clock-names = "cam_clk";

--- a/arch/arm64/boot/dts/qcom/monaco-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-camera-sensor.dtsi
@@ -147,8 +147,8 @@
 			     &cam_sensor_suspend_rst0>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 67 0>,
-			<&tlmm 73 0>,
-			<&expander2 0 0>;
+			<&expander2 0 0>,
+			<&tlmm 73 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -187,8 +187,8 @@
 		             &cam_sensor_suspend_rst0>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 67 0>,
-			<&tlmm 73 0>,
-			<&expander2 0 0>;
+			<&expander2 0 0>,
+			<&tlmm 73 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -221,8 +221,8 @@
 			     &cam_sensor_suspend_rst0>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 67 0>,
-			<&tlmm 73 0>,
-			<&expander2 0 0>;
+			<&expander2 0 0>,
+			<&tlmm 73 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -382,8 +382,8 @@
 			     &cam_sensor_suspend_rst1>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 68 0>,
-			<&tlmm 74 0>,
-			<&expander2 1 0>;
+			<&expander2 1 0>,
+			<&tlmm 74 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -422,8 +422,8 @@
 			     &cam_sensor_suspend_rst1>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 68 0>,
-			<&tlmm 74 0>,
-			<&expander2 1 0>;
+			<&expander2 1 0>,
+			<&tlmm 74 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -456,8 +456,8 @@
 			     &cam_sensor_suspend_rst1>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 68 0>,
-			<&tlmm 74 0>,
-			<&expander2 1 0>;
+			<&expander2 1 0>,
+			<&tlmm 74 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -617,8 +617,8 @@
 			     &cam_sensor_suspend_rst2>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 69 0>,
-			<&tlmm 75 0>,
-			<&expander2 2 0>;
+			<&expander2 2 0>,
+			<&tlmm 75 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -657,8 +657,8 @@
 			     &cam_sensor_suspend_rst2>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 69 0>,
-			<&tlmm 75 0>,
-			<&expander2 2 0>;
+			<&expander2 2 0>,
+			<&tlmm 75 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;
@@ -691,8 +691,8 @@
 			     &cam_sensor_suspend_rst2>;
 		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 69 0>,
-			<&tlmm 75 0>,
-			<&expander2 2 0>;
+			<&expander2 2 0>,
+			<&tlmm 75 0>;
 		gpio-reset = <1>;
 		gpio-custom1 = <2>;
 		gpio-req-tbl-num = <0 1 2>;


### PR DESCRIPTION
Removing non-required imx577 sensor node definition for cci1 for monaco.
&&
Swap reset and power down pins for MIPI camera.

CRs-Fixed: 4429303
CRs-Fixed: 4593671