### PR TITLE
drm/msm: Add Adreno A704 GPU support for Shikra SoC

### DIFF
--- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
@@ -1454,7 +1454,7 @@ DECLARE_ADRENO_REGLIST_PIPE_LIST(a7xx_dyn_pwrup_reglist);
 
 static const struct adreno_info a7xx_gpus[] = {
 	{
-		.chip_ids = ADRENO_CHIP_IDS(0x07000200),
+		.chip_ids = ADRENO_CHIP_IDS(0x07000200, 0x07000400),
 		.family = ADRENO_6XX_GEN1, /* NOT a mistake! */
 		.fw = {
 			[ADRENO_FW_SQE] = "a702_sqe.fw",


### PR DESCRIPTION
Adds upstream support for the Adreno A704 GPU found in the Shikra SoC. Since A704 is largely an IP reuse of the existing A702 GPU with minimal hardware differences, support is enabled by extending the existing A702 framework with the new GPU chip ID. 

CRs-Fixed: 4596586