### PR TITLE
drm/bridge: lt9611c: use drm_atomic_commit in callbacks

### DIFF
--- a/drivers/gpu/drm/bridge/lontium-lt9611c.c
+++ b/drivers/gpu/drm/bridge/lontium-lt9611c.c
@@ -650,7 +650,7 @@ static void lt9611c_video_setup(struct lt9611c *lt9611c,
 }
 
 static void lt9611c_bridge_atomic_pre_enable(struct drm_bridge *bridge,
-					     struct drm_atomic_state *state)
+					     struct drm_atomic_commit *state)
 {
 	struct lt9611c *lt9611c = bridge_to_lt9611c(bridge);
 	int ret;
@@ -661,7 +661,7 @@ static void lt9611c_bridge_atomic_pre_enable(struct drm_bridge *bridge,
 }
 
 static void lt9611c_bridge_atomic_enable(struct drm_bridge *bridge,
-					 struct drm_atomic_state *state)
+					 struct drm_atomic_commit *state)
 {
 	struct lt9611c *lt9611c = bridge_to_lt9611c(bridge);
 	struct drm_connector *connector;
@@ -687,7 +687,7 @@ static void lt9611c_bridge_atomic_enable(struct drm_bridge *bridge,
 }
 
 static void lt9611c_bridge_atomic_post_disable(struct drm_bridge *bridge,
-					       struct drm_atomic_state *state)
+					       struct drm_atomic_commit *state)
 {
 	struct lt9611c *lt9611c = bridge_to_lt9611c(bridge);
 	int ret;
@@ -1328,4 +1328,3 @@ MODULE_AUTHOR("SunYun Yang <syyang@lontium.com>");
 MODULE_DESCRIPTION("Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver");
 MODULE_LICENSE("GPL");
 MODULE_FIRMWARE(FW_FILE);
-


### PR DESCRIPTION
DRM bridge atomic callbacks now pass struct drm_atomic_commit, and the atomic helper functions also expect that type. The lt9611c driver still declares its callbacks with struct drm_atomic_state, which makes the callback assignments and helper calls fail to build with incompatible pointer type errors.

Update the lt9611c callback signatures to match the current DRM bridge API.

This will fix compilation issue in v7.2.rc1.

Fixes: 96d1cfec419e ("drm/bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver")

CRs-Fixed: 4552827