### PR TITLE
QCLINUX: arm64: dts: qcom: Enable og0va1b camera sensor on glymur crd

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-camera-sensor.dtsi
@@ -23,9 +23,6 @@
 		rgltr-max-voltage = <1800000 2800000>;
 		rgltr-load-current = <204000 55000>;
 		gpio-no-mux = <0>;
-		pinctrl-0 = <&cam_sensor_mclk4_active &cam_sensor_active_rst4>;
-		pinctrl-1 = <&cam_sensor_mclk4_suspend &cam_sensor_suspend_rst4>;
-		pinctrl-names = "cam_default", "cam_suspend";
 		gpios = <&tlmm 100 0>,
 			<&tlmm 239 0>;
 		gpio-reset = <1>;
@@ -41,11 +38,49 @@
 		cell-index = <0>;
 		status = "okay";
 	};
+
+	/*cam1-og0va1b*/
+	qcom,cam-sensor1 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <0>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		cam_vio-supply = <&vreg_l4p>;
+		cam_vana-supply = <&vreg_l3p>;
+		regulator-names = "cam_vio", "cam_vana";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000 2800000>;
+		rgltr-max-voltage = <1960000 3312000>;
+		rgltr-load-current = <36000 35000>;
+		gpio-no-mux = <0>;
+		gpios = <&tlmm 100 0>,
+			<&tlmm 109 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAM_MCLK4",
+				     "CAMIF_RESET0";
+		cci-master = <1>;
+		clocks = <&camcc CAM_CC_MCLK4_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <1>;
+		status = "okay";
+	};
 };
 
 &soc {
 	qcom,cam-res-mgr {
 		compatible = "qcom,cam-res-mgr";
+		gpios-shared-pinctrl = <760>;
+		pinctrl-names = "mclk4_active", "mclk4_suspend";
+		pinctrl-0 = <&cam_sensor_mclk4_active>;
+		pinctrl-1 = <&cam_sensor_mclk4_suspend>;
+		shared-pctrl-gpio-names = "mclk4";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Enable camera sensors og0va1b on the Glymur CRD platform.

Adds required DT updates to support sensor bring-up and probe on Glymur crd board.

CRs-Fixed: 4590425