### PR TITLE
QCLINUX: arm64: dts: qcom: Add rb3gen2 SDE overlay dts

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -597,3 +597,7 @@ dtb-$(CONFIG_ARCH_QCOM) += sm8750-staging.dtbo
 dtb-$(CONFIG_ARCH_QCOM) += kaanapali-staging.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += shikra-staging.dtbo
+
+qcs6490-rb3gen2-sde-dtbs := qcs6490-rb3gen2.dtb qcs6490-rb3gen2-sde.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM) += qcs6490-rb3gen2-sde.dtb

--- a/arch/arm64/boot/dts/qcom/kodiak-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/kodiak-sde.dtsi
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
+ */
+
+#include <dt-bindings/clock/qcom,gcc-sc7280.h>
+#include <dt-bindings/clock/qcom,dispcc-sc7280.h>
+#include <dt-bindings/interconnect/qcom,icc.h>
+#include <dt-bindings/interconnect/qcom,sc7280.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/power/qcom-rpmpd.h>
+#include <dt-bindings/clock/qcom,rpmh.h>
+
+&soc {
+	smmu_sde_unsec: qcom,smmu_sde_unsec_cb {
+		compatible = "qcom,smmu_sde_unsec";
+		iommus = <&apps_smmu 0x900 0x402>;
+		qcom,iommu-dma-addr-pool = <0x00020000 0xfffe0000>;
+		qcom,iommu-faults = "non-fatal";
+		dma-coherent;
+		clocks = <&dispcc DISP_CC_MDSS_MDP_CLK>;
+		clock-names = "mdp_core_clk";
+	};
+
+	sde_edp_pll: qcom,edp_pll@aec2a00 {
+		status = "ok";
+		compatible = "qcom,edp-pll-7nm";
+		label = "dp3";
+		#clock-cells = <1>;
+	};
+
+
+	mdss_mdp0: qcom,mdss_mdp0@ae00000 {
+		status = "disabled";
+		compatible = "qcom,sde-kms";
+		reg = <0 0x0ae00000 0 0x84000>,
+			<0 0x0aeb0000 0 0x2008>,
+			<0 0x0aeac000 0 0x800>;
+		reg-names = "mdp_phys",
+			"vbif_phys",
+			"regdma_phys";
+
+		power-domains = <&dispcc DISP_CC_MDSS_CORE_GDSC>;
+		clocks = <&gcc GCC_DISP_HF_AXI_CLK>,
+			<&gcc GCC_DISP_SF_AXI_CLK>,
+			<&dispcc DISP_CC_MDSS_AHB_CLK>,
+			<&dispcc DISP_CC_MDSS_MDP_CLK>,
+			<&dispcc DISP_CC_MDSS_VSYNC_CLK>,
+			<&dispcc DISP_CC_MDSS_MDP_LUT_CLK>;
+		clock-names = "bus", "nrt_bus",
+				"iface", "core_clk", "vsync",
+				"lut";
+		clock-rate = <0 0 0 506666667 19200000 506666667>;
+		clock-max-rate = <0 0 0 608000000 19200000 608000000>;
+
+		interconnects = <&mmss_noc MASTER_MDP0 0 &gem_noc SLAVE_LLCC 0>,
+				<&mc_virt MASTER_LLCC 0 &mc_virt SLAVE_EBI1 0>,
+				<&gem_noc MASTER_APPSS_PROC 0 &cnoc2 SLAVE_DISPLAY_CFG 0>;
+		interconnect-names = "qcom,sde-data-bus0", "qcom,sde-ebi-bus", "qcom,sde-reg-bus";
+		qcom,sde-ib-bw-vote = <2500000 0 800000>;
+
+		interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+
+		qcom,sde-off = <0x1000>;
+		qcom,sde-len = <0x494>;
+
+		qcom,sde-ctl-off = <0x16000 0x17000 0x18000
+					0x19000>;
+		qcom,sde-ctl-size = <0x1e8>;
+		qcom,sde-ctl-display-pref = "primary", "none", "none",
+						"none";
+
+		qcom,sde-mixer-off = <0x45000 0x45000 0x47000 0x48000>;
+		qcom,sde-mixer-size = <0x320>;
+		qcom,sde-mixer-display-pref = "primary", "none",
+						"none", "none";
+
+		qcom,sde-dspp-top-off = <0x1300>;
+		qcom,sde-dspp-top-size = <0x80>;
+		qcom,sde-dspp-off = <0x55000>;
+		qcom,sde-dspp-size = <0x1800>;
+		qcom,sde-intf-off = <0x35000 0x36000 0x37000
+				     0x38000 0x39000 0x3a000>;
+		qcom,sde-intf-size = <0x2c4>;
+		qcom,sde-intf-type = "dp", "dsi", "none",
+				     "none", "none", "dp";
+		qcom,sde-intf-tear-irq-off = <0 0x36800 0>;
+		qcom,sde-pp-off = <0x6a000 0x6b000
+					0x6c000 0x6d000>;
+		qcom,sde-pp-slave = <0x0 0x0 0x0 0x0>;
+		qcom,sde-pp-size = <0xd4>;
+		qcom,sde-pp-merge-3d-id = <0x0 0x0 0x1 0x1>;
+		qcom,sde-merge-3d-off = <0x50000 0x50000>;
+		qcom,sde-merge-3d-size = <0x10>;
+		qcom,sde-cdm-off = <0x7a200>;
+		qcom,sde-cdm-size = <0x224>;
+		qcom,sde-dsc-off = <0x81000>;
+		qcom,sde-dsc-size = <0x10>;
+		qcom,sde-dsc-hw-rev = "dsc_1_2";
+		qcom,sde-dsc-enc = <0x100>;
+		qcom,sde-dsc-enc-size = <0x100>;
+		qcom,sde-dsc-ctl = <0xF00>;
+		qcom,sde-dsc-ctl-size = <0x10>;
+		qcom,sde-dsc-native422-supp = <1>;
+		qcom,sde-dsc-linewidth = <2048>;
+		qcom,sde-dither-off = <0xe0 0xe0 0xe0 0xe0>;
+		qcom,sde-dither-version = <0x00020000>;
+		qcom,sde-dither-size = <0x20>;
+		qcom,sde-sspp-type = "vig",
+					"dma", "dma", "dma";
+		qcom,sde-sspp-off = <0x5000
+					0x25000 0x27000 0x29000>;
+		qcom,sde-sspp-src-size = <0x1f8>;
+		qcom,sde-sspp-xin-id = <0
+					1 5 9>;
+		qcom,sde-sspp-excl-rect = <1 1 1 1>;
+		qcom,sde-sspp-smart-dma-priority = <4 1 2 3>;
+		qcom,sde-smart-dma-rev = "smart_dma_v2p5";
+		qcom,sde-mixer-pair-mask = <0 0 4 3>;
+		qcom,sde-mixer-blend-op-off = <0x20 0x38 0x50 0x68 0x80 0x98
+						0xb0 0xc8 0xe0 0xf8 0x110>;
+		qcom,sde-max-per-pipe-bw-kbps = <4300000 4300000
+						4300000 4300000>;
+		qcom,sde-max-per-pipe-bw-high-kbps = <4300000 4300000
+						4300000 4300000>;
+		qcom,sde-sspp-clk-ctrl = <0x2ac 0>,
+						<0x2ac 8>, <0x2b4 8>, <0x2c4 8>;
+		qcom,sde-sspp-clk-status = <0x2b0 0>,
+						<0x2b0 12>, <0x2b8 12>, <0x2c8 12>;
+		qcom,sde-sspp-csc-off = <0x1a00>;
+		qcom,sde-csc-type = "csc-10bit";
+		qcom,sde-qseed-sw-lib-rev = "qseedv3lite";
+		qcom,sde-qseed-scalar-version = <0x3000>;
+		qcom,sde-sspp-qseed-off = <0xa00>;
+		qcom,sde-mixer-linewidth = <2560>;
+		qcom,sde-sspp-linewidth = <2400>;
+		qcom,sde-vig-sspp-linewidth = <4096>;
+		qcom,sde-scaling-linewidth = <2560>;
+		qcom,sde-wb-linewidth = <4096>;
+		qcom,sde-wb-linewidth-linear = <4096>;
+		qcom,sde-mixer-blendstages = <0x9>;
+		qcom,sde-highest-bank-bit = <0x8 0x2>,
+						<0x7 0x1>;
+		qcom,sde-ubwc-version = <0x30000000>;
+		qcom,sde-ubwc-swizzle = <0x6>;
+		qcom,sde-ubwc-bw-calc-version = <0x1>;
+		qcom,sde-ubwc-static = <0x1>;
+		qcom,sde-macrotile-mode = <0x1>;
+		qcom,sde-smart-panel-align-mode = <0xc>;
+		qcom,sde-panic-per-pipe;
+		qcom,sde-has-cdp;
+		qcom,sde-has-src-split;
+		qcom,sde-pipe-order-version = <0x1>;
+		qcom,sde-has-dim-layer;
+		qcom,sde-max-trusted-vm-displays = <1>;
+		qcom,sde-max-bw-low-kbps = <4700000>;
+		qcom,sde-max-bw-high-kbps = <8800000>;
+		qcom,sde-min-core-ib-kbps = <2500000>;
+		qcom,sde-min-llcc-ib-kbps = <0>;
+		qcom,sde-min-dram-ib-kbps = <1600000>;
+		qcom,sde-dram-channels = <2>;
+		qcom,sde-num-nrt-paths = <0>;
+
+		qcom,sde-wb-off = <0x66000>;
+		qcom,sde-wb-size = <0x2c8>;
+		qcom,sde-wb-xin-id = <6>;
+		qcom,sde-wb-id = <2>;
+		qcom,sde-wb-clk-ctrl = <0x2bc 16>;
+		qcom,sde-wb-clk-status = <0x3bc 20>;
+
+		qcom,sde-uidle-off = <0x80000>;
+		qcom,sde-uidle-size = <0x70>;
+		qcom,sde-vbif-off = <0>;
+		qcom,sde-vbif-size = <0x1040>;
+		qcom,sde-vbif-id = <0>;
+		qcom,sde-vbif-memtype-0 = <3 3 3 3 3 3 3 3>;
+		qcom,sde-vbif-memtype-1 = <3 3 3 3 3 3>;
+
+		qcom,sde-vbif-qos-rt-remap = <4 4 5 5 5 5 5 6 4 4 5 5 5 5 5 6>;
+		qcom,sde-vbif-qos-nrt-remap = <3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3>;
+		qcom,sde-vbif-qos-cwb-remap = <4 4 5 5 5 5 5 6 4 4 5 5 5 5 5 6>;
+		qcom,sde-vbif-qos-lutdma-remap = <4 4 4 4 5 5 5 5 4 4 4 4 5 5 5 5>;
+
+		qcom,sde-danger-lut = <0xffff 0xffff 0xffff 0xffff 0x0 0x0 0x0 0x0
+					0x0 0x0 0xffff 0xffff 0xffff 0xffff 0x0 0x0 0xffff0000 0xffff0000>;
+
+		qcom,sde-safe-lut = <0xff00 0xfff0 0xff00 0xfff0 0xffff 0xffff 0x0001 0x0001
+					0x03ff 0x03ff 0xff00 0xfff0 0xff00 0xfff0 0xffff 0xffff 0xff 0xff>;
+
+		qcom,sde-creq-lut = <0x00112233 0x44556666 0x00112233 0x66666666
+					0x00112233 0x44556666 0x00112233 0x66666666
+					0x0        0x0        0x0        0x0
+					0x77776666 0x66666540 0x77776666 0x66666540
+					0x77776541 0x0        0x77776541 0x0
+					0x00112233 0x44556666 0x00112233 0x66666666
+					0x00112233 0x44556666 0x00112233 0x66666666
+					0x0        0x0        0x0        0x0
+					0x55555544 0x33221100 0x55555544 0x33221100>;
+
+		qcom,sde-cdp-setting = <1 1>, <1 0>;
+
+		qcom,sde-qos-cpu-mask = <0x3>;
+		qcom,sde-qos-cpu-mask-performance = <0xf>;
+		qcom,sde-qos-cpu-dma-latency = <300>;
+		qcom,sde-qos-cpu-irq-latency = <300>;
+
+		qcom,sde-reg-dma-off = <0 0x400>;
+		qcom,sde-reg-dma-id = <0 1>;
+		qcom,sde-reg-dma-version = <0x00020000>;
+		qcom,sde-reg-dma-trigger-off = <0x119c>;
+		qcom,sde-reg-dma-xin-id = <7>;
+		qcom,sde-reg-dma-clk-ctrl = <0x2bc 20>;
+
+		qcom,sde-secure-sid-mask = <0x901 0xD01>;
+
+		qcom,sde-reg-bus,vectors-KBps = <0 0>,
+						<0 74000>,
+						<0 148000>,
+						<0 265000>;
+
+		qcom,sde-sspp-vig-blocks {
+			qcom,sde-vig-csc-off = <0x1a00>;
+			qcom,sde-vig-qseed-off = <0xa00>;
+			qcom,sde-vig-qseed-size = <0xa0>;
+			qcom,sde-vig-gamut = <0x1d00 0x00060001>;
+			qcom,sde-vig-igc = <0x1d00 0x00060000>;
+			qcom,sde-vig-inverse-pma;
+		};
+
+		qcom,sde-sspp-dma-blocks {
+			dgm@0 {
+				cell-index = <0>;
+				qcom,sde-dma-igc = <0x400 0x00050000>;
+				qcom,sde-dma-gc = <0x600 0x00050000>;
+				qcom,sde-dma-inverse-pma;
+				qcom,sde-dma-csc-off = <0x200>;
+			};
+
+			dgm@1 {
+				cell-index = <1>;
+				qcom,sde-dma-igc = <0x1400 0x00050000>;
+				qcom,sde-dma-gc = <0x600 0x00050000>;
+				qcom,sde-dma-inverse-pma;
+				qcom,sde-dma-csc-off = <0x1200>;
+			};
+		};
+
+		qcom,sde-dspp-blocks {
+			qcom,sde-dspp-igc = <0x1260 0x00040000>;
+			qcom,sde-dspp-hsic = <0x800 0x00010007>;
+			qcom,sde-dspp-memcolor = <0x880 0x00010007>;
+			qcom,sde-dspp-hist = <0x800 0x00010007>;
+			qcom,sde-dspp-sixzone= <0x900 0x00010007>;
+			qcom,sde-dspp-vlut = <0xa00 0x00010008>;
+			qcom,sde-dspp-gamut = <0x1000 0x00040003>;
+			qcom,sde-dspp-pcc = <0x1700 0x00040000>;
+			qcom,sde-dspp-gc = <0x17c0 0x00010008>;
+			qcom,sde-dspp-dither = <0x82c 0x00010007>;
+		};
+	};
+
+	qcom_msmhdcp: qcom,msm_hdcp {
+		compatible = "qcom,msm-hdcp";
+	};
+
+	mdss_edp0: qcom,edp_display@aea0000 {
+		status = "disabled";
+		cell-index = <1>;
+		qcom,intf-index = <1>;
+		compatible = "qcom,edp-display";
+		label = "edp";
+
+		reg =   <0 0xaea0000 0 0x0fc>,
+			<0 0xaea0200 0 0x0c0>,
+			<0 0xaea0400 0 0x770>,
+			<0 0xaea1000 0 0x098>,
+			<0 0xaec2a00 0 0x200>,
+			<0 0xaec2200 0 0x200>,
+			<0 0xaec2600 0 0x200>,
+			<0 0xaf01188 0 0x1f>,
+			<0 0xaec2000 0 0x200>,
+			<0 0xaee4000 0 0x034>,
+			<0 0xaf01004 0 0x8>;
+		reg-names = "dp_ahb", "dp_aux", "dp_link",
+			"dp_p0", "dp_phy", "dp_ln_tx0", "dp_ln_tx1",
+			"dp_mmss_cc", "dp_pll",
+			"hdcp_physical", "gdsc";
+
+		qcom,pclk-reg-off = <0>;
+		interrupt-parent = <&mdss_mdp0>;
+		interrupts = <14 0>;
+
+		qcom,dp-aux-switch = <&mdss_edp0>;
+		qcom,dp-low-power-hw-hpd;
+
+		#clock-cells = <1>;
+		clocks =  <&dispcc DISP_CC_MDSS_EDP_AUX_CLK>,
+			<&rpmhcc RPMH_CXO_CLK>,
+			<&gcc GCC_EDP_CLKREF_EN>,
+			<&dispcc DISP_CC_MDSS_EDP_LINK_CLK>,
+			<&dispcc DISP_CC_MDSS_EDP_LINK_CLK_SRC>,
+			<&dispcc DISP_CC_MDSS_EDP_LINK_INTF_CLK>,
+			<&sde_edp_pll 0>,
+			<&dispcc DISP_CC_MDSS_EDP_PIXEL_CLK_SRC>,
+			<&sde_edp_pll 1>,
+			<&rpmhcc RPMH_CXO_CLK>,
+			<&dispcc DISP_CC_MDSS_EDP_PIXEL_CLK>;
+		clock-names = "core_aux_clk", "rpmh_cxo_clk", "core_edp_refclk",
+			"link_clk", "link_clk_src", "link_iface_clk",
+			"link_parent",
+			"pixel_clk_rcg", "pixel_parent",
+			"pixel1_clk_rcg",
+			"strm0_pixel_clk";
+
+		qcom,pll-revision = "edp-7nm";
+		qcom,phy-version = <0x500>;
+		qcom,phy-mode = "edp";
+                qcom,dp-pll = <&sde_edp_pll>; 
+		qcom,aux-cfg0-settings = [24 00];
+		qcom,aux-cfg1-settings = [28 13];
+		qcom,aux-cfg2-settings = [2c 24];
+		qcom,aux-cfg3-settings = [30 00];
+		qcom,aux-cfg4-settings = [34 0a];
+		qcom,aux-cfg5-settings = [38 26];
+		qcom,aux-cfg6-settings = [3c 0a];
+		qcom,aux-cfg7-settings = [40 03];
+		qcom,aux-cfg8-settings = [44 37];
+		qcom,aux-cfg9-settings = [4c 03];
+
+		qcom,max-pclk-frequency-khz = <185625>;
+		qcom,display-type = "primary";
+
+		qcom,ssc-feature-enable;
+		qcom,dsc-feature-enable;
+		qcom,fec-feature-enable;
+
+		qcom,qos-cpu-mask = <0xf>;
+		qcom,qos-cpu-latency-us = <300>;
+
+		qcom,ctrl-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,ctrl-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-1p2";
+				qcom,supply-min-voltage = <1200000>;
+				qcom,supply-max-voltage = <1200000>;
+				qcom,supply-enable-load = <30100>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+		qcom,phy-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,phy-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-0p9";
+				qcom,supply-min-voltage = <880000>;
+				qcom,supply-max-voltage = <880000>;
+				qcom,supply-enable-load = <115000>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+		qcom,pll-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,pll-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdd_mx";
+				qcom,supply-min-voltage =
+						<RPMH_REGULATOR_LEVEL_TURBO>;
+				qcom,supply-max-voltage =
+						<65535>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "refgen";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+	};
+};
+
+&dispcc {
+        clocks = <&rpmhcc RPMH_CXO_CLK>,
+                <&gcc GCC_DISP_GPLL0_CLK_SRC>,
+                <&sde_edp_pll 0>,
+                <&sde_edp_pll 1>;
+        clock-names = "bi_tcxo",
+                "gcc_disp_gpll0_clk",
+                "edp_phy_pll_link_clk",
+                "edp_phy_pll_vco_div_clk";
+
+};
+
+&mdss {
+       status = "disabled";
+};
+
+&mdss_dsi {
+       status = "disabled";
+};
+
+&mdss_dsi_phy {
+       status = "disabled";
+};
+
+&mdss_edp {
+       status = "disabled";
+};
+
+&mdss_edp_phy {
+       status = "disabled";
+};
+
+&mdss_dp {
+       status = "disabled";
+};

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-sde.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-sde.dtso
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include "kodiak-sde.dtsi"
+
+&mdss_mdp0 {
+	status = "okay";
+        connectors = <&smmu_sde_unsec &mdss_edp0>;
+};
+
+&mdss_edp0 {
+	status = "okay";
+        qcom,display-type = "primary";
+        qcom,dp-low-power-hw-hpd;
+        vdda-1p2-supply = <&vreg_l6b_1p2>;
+        vdda-0p9-supply = <&vreg_l10c_0p88>;
+        pinctrl-names = "mdss_dp_active", "mdss_dp_sleep", "mdss_dp_hpd_active";
+        pinctrl-0 = <&edp_hpd_ctrl>;
+        pinctrl-1 = <&edp_hpd_default>;
+        pinctrl-2 = <&edp_hpd_default>;
+        qcom,dp-hpd-gpio = <&tlmm 60 0>;
+        qcom,dp-gpio-aux-switch;
+        qcom,edp-vcc-en-gpio = <&tlmm 80 0>;
+        qcom,no-backlight-support;
+        qcom,dp-ext-hpd;
+};
+
+&tlmm {
+        edp_hpd_default: hpd_default@60 {
+                mux {
+                        pins = "gpio60";
+                        function = "gpio";
+                };
+
+                config {
+                        pins = "gpio60";
+                        bias-disable;
+                        input-enable;
+                        drive-strength = <2>;
+                };
+        };
+        edp_hpd_ctrl: hpd_ctrl@60 {
+                mux {
+                        pins = "gpio60";
+                        function = "edp_hot";
+                };
+
+                config {
+                        pins = "gpio60";
+                        bias-disable;
+                        input-enable;
+                        drive-strength = <2>;
+                };
+        };
+};


### PR DESCRIPTION
Add SDE (Snapdragon Display Engine) overlay dts for RB3gen2 (QCS6490/Kodiak) board including MDSS, MDP, DSI, eDP nodes and enables its compilation in the Makefile.