### PR TITLE
FROMLIST: media: iris: avoid bit depth validation for capture formats

### DIFF
--- a/drivers/media/platform/qcom/iris/iris_vdec.c
+++ b/drivers/media/platform/qcom/iris/iris_vdec.c
@@ -100,16 +100,6 @@ static bool check_format(struct iris_inst *inst, u32 pixfmt, u32 type)
 	if (i == size)
 		return false;
 
-	if (type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
-		if (iris_fmt_is_8bit(pixfmt) &&
-		    inst->fw_caps[BIT_DEPTH].value == BIT_DEPTH_10)
-			return false;
-
-		if (iris_fmt_is_10bit(pixfmt) &&
-		    inst->fw_caps[BIT_DEPTH].value != BIT_DEPTH_10)
-			return false;
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
When validating a capture format, check_format() compares the requested pixel format against inst->fw_caps[BIT_DEPTH]. However, the bit depth capability is not available at this stage and it contains the default value of BIT_DEPTH_8. The actual bit depth is updated later after the firmware reports stream capabilities through read_input_subcr_params(). Because of this, a valid client request of QC10C format request is rejected during the initial format negotiation. The driver then falls back to the default capture format (NV12) and stores it as capture format. Later, when the firmware reports that the stream is 10-bit, the driver sees NV12 as the selected capture format and switches to the default 10-bit format (P010). As a result, the original QC10C format requested by userspace is lost and QC10C decoding cannot work correctly. The bit depth information is not reliable during the initial format setup, so it should not be used to validate capture formats. Remove the bit-depth checks from check_format() and only verify that the requested pixel format is supported. This allows the format requested by userspace is handled correctly.

Fixes: 20c3ef4c7cae ("media: qcom: iris: vdec: update find_format to handle 8bit and 10bit formats")
Cc: stable@vger.kernel.org
Reviewed-by: Vikash Garodia <vikash.garodia@oss.qualcomm.com>
Link: https://lore.kernel.org/all/20260710-qc10c_fix_and_disable_time_delta_based_rc-v2-1-701d6dfd1ac1@oss.qualcomm.com/