### PR TITLE
Revert Shikra: Enable CDSP cooling

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -4881,14 +4881,6 @@
 					};
 				};
 			};
-
-			cooling {
-				compatible = "qcom,qmi-cooling-cdsp";
-					cdsp_sw: cdsp_sw {
-						label = "cdsp_sw";
-						#cooling-cells = <2>;
-					};
-			};
 		};
 
 		remoteproc_lpaicp: remoteproc@b800000 {
@@ -5119,24 +5111,10 @@
 					type = "hot";
 				};
 
-				nsp_0_alert0: trip-point1 {
-					temperature = <115000>;
-					hysteresis = <5000>;
-					type = "passive";
-				};
-
 				nsp-critical {
-					temperature = <118000>;
+					temperature = <115000>;
 					hysteresis = <0>;
 					type = "critical";
-				};
-			};
-
-			cooling-maps {
-				map0 {
-					trip = <&nsp_0_alert0>;
-					cooling-device = <&cdsp_sw
-							  THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
 				};
 			};
 		};


### PR DESCRIPTION
Reverts qualcomm-linux/kernel-topics#1306
Reverting the PR #1306, as it is being replaced by the QMI-TMD v3 patch series which carries the updated CDSP thermal cooling implementation. 