### PR TITLE
FROMLIST: arm64: dts: qcom: shikra: Add qcom,vmid to BAM-DMA node

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -28,7 +28,7 @@
 	#size-cells = <2>;
 
 	bam_dmux: bam-dmux {
-		compatible = "qcom,bam-dmux";
+		compatible = "qcom,shikra-bam-dmux", "qcom,bam-dmux";
 
 		interrupts-extended =
 			<&modem_smsm 1 IRQ_TYPE_EDGE_BOTH>,
@@ -3450,7 +3450,7 @@
 		};
 
 		bam_dmux_dma: dma-controller@6044000 {
-			compatible = "qcom,bam-v1.7.0";
+			compatible = "qcom,shikra-bam-dma", "qcom,bam-v1.7.0";
 			reg = <0x0 0x06044000 0x0 0x19000>;
 			interrupts = <GIC_SPI 74 IRQ_TYPE_EDGE_RISING 0>;
 			#dma-cells = <1>;
@@ -3459,6 +3459,7 @@
 			num-channels = <6>;
 			qcom,num-ees = <1>;
 			qcom,powered-remotely;
+			qcom,vmid = <QCOM_SCM_VMID_NAV>;
 		};
 
 		remoteproc_mpss: remoteproc@6080000 {


### PR DESCRIPTION
On the Qualcomm Shikra SoC the mDSP (VMID 43 / QCOM_SCM_VMID_NAV) is the AXI master for BAM descriptor FIFO accesses. The XPU enforces per-region access control; without an SCM assignment granting NAV access, the first DMA transfer triggers an XPU violation.

Add qcom,vmid = <QCOM_SCM_VMID_NAV> to the bam_dmux_dma controller node so bam_dma SCM-assigns each channel descriptor FIFO at allocation. BAM-DMUX itself is a singleton and no longer needs a DT property for its destination VMID: the driver now selects QCOM_SCM_VMID_NAV internally via the qcom,shikra-bam-dmux compatible's match data.

Co-developed-by: Deepak Kumar Singh <deepak.singh@oss.qualcomm.com>


Link: https://lore.kernel.org/r/20260714-b4-qcom-shikra-dts-bam-dmux-vmid-ext-v1-1-5b19da8d7735@oss.qualcomm.com