### PR TITLE
thermal: qcom-tsens: Document the Maili Temperature Sensor

### DIFF
--- a/Documentation/devicetree/bindings/thermal/qcom-tsens.yaml
+++ b/Documentation/devicetree/bindings/thermal/qcom-tsens.yaml
@@ -58,6 +58,7 @@ properties:
               - qcom,glymur-tsens
               - qcom,hawi-tsens
               - qcom,kaanapali-tsens
+              - qcom,maili-tsens
               - qcom,milos-tsens
               - qcom,nord-tsens
               - qcom,msm8953-tsens


### PR DESCRIPTION
Document the Temperature Sensor (TSENS) on the Qualcomm Maili SoC.