### PR TITLE
ARM: dts: qcom: revert back pmic-arb to the LEVEL trigger setting

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -1391,7 +1391,7 @@
 				    "obsrvr",
 				    "intr",
 				    "cnfg";
-			interrupts-extended = <&mpm 86 IRQ_TYPE_EDGE_RISING>;
+			interrupts-extended = <&mpm 86 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "periph_irq";
 			interrupt-controller;
 			#interrupt-cells = <4>;


### PR DESCRIPTION
Traditionally on all targets PMIC-ARB top-level IRQ (coming out from GIC to CPU) was LEVEL triggered. However, for Shikra target this had to be changed to EDGE, as the GIC input IRQ from the PMIC-ARB HW block was changed to EDGE by HW team.

Without it, the input/output trigger type mismatch was leading to SPMI irqs not work.

However, when the VDDMIN(APPS suspend) path was enabled, the USB detection was failing after VDDMIN exit. This was happening because during the VDDMIN exit, the IRQs are relayed from the MPM (rather than GIC), and when the exit happens, there is a window, where the IRQs were missed due to the EDGE trigger logic, by the GIC, and it appears because of that all the subsequent IRQs are missed.

To fix this HW team has recommended to switch back to the LEVEL setting. So, add the needed DT change for it.

Note - A corresponding change will be added in the TZ code as well, to make the PMIC-ARB -> GIC HW block LEVEL trigger.

Change-Id: I907149dd3ce18ec4b10bf8874eaa18ae0faa87c5

CRs-fixed: 4535808