### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: enable audio ML offload memory an…

### DIFF
--- a/Documentation/devicetree/bindings/remoteproc/qcom,pas-common.yaml
+++ b/Documentation/devicetree/bindings/remoteproc/qcom,pas-common.yaml
@@ -45,7 +45,8 @@ properties:
       - const: shutdown-ack
 
   iommus:
-    maxItems: 1
+    minItems: 1
+    maxItems: 3
 
   power-domains:
     minItems: 1

--- a/arch/arm64/boot/dts/qcom/lemans-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/lemans-el2.dtso
@@ -21,7 +21,9 @@
 };
 
 &remoteproc_adsp {
-	iommus = <&apps_smmu 0x3000 0x0>;
+	iommus = <&apps_smmu 0x3000 0x0>,
+		<&apps_smmu 0x3060 0x9>,
+		<&apps_smmu 0x3062 0x1>;
 };
 
 &remoteproc_cdsp0 {

--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -689,6 +689,14 @@
 		#size-cells = <2>;
 		ranges;
 
+		audio_cma_mem: qcom,audio-ml {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1000000>;
+		};
+
 		sail_ss_mem: sail-ss@80000000 {
 			reg = <0x0 0x80000000 0x0 0x10000000>;
 			no-map;
@@ -8239,6 +8247,7 @@
 						q6apmdai: dais {
 							compatible = "qcom,q6apm-dais";
 							iommus = <&apps_smmu 0x3001 0x0>;
+							memory-region = <&audio_cma_mem>;
 						};
 					};
 


### PR DESCRIPTION
    The audio ML (machine-learning) offload use case requires a contiguous,
    physically addressable buffer shared with the audio DSP/SPF, and issues
    DMA transactions through additional SMMU stream IDs that are not
    covered by the existing ADSP mapping.

    Add a dedicated reusable shared-dma-pool CMA region (16 MiB, 4 MiB
    aligned) and wire it to the q6apm DAIs node via memory-region. A
    dedicated pool guarantees the alignment and contiguity the DSP expects
    and isolates these allocations from the default CMA region.

    Under the EL2 (Gunyah/hypervisor) configuration the SMMU is fully
    enforcing, so the ML transactions are otherwise blocked and faulted:

     arm-smmu 15000000.iommu: Blocked unknown Stream ID 0x3060
     arm-smmu 15000000.iommu: Blocked unknown Stream ID 0x3062

    Add the ML-related stream IDs (0x3060 mask 0x9, 0x3062 mask 0x1) to the
    remoteproc_adsp iommus property in the EL2 overlay so these buffers are
    translated by the SMMU instead of being rejected.
