### PR TITLE
FROMLIST: arm64: dts: qcom: monaco: enable audio ML offload memory an…

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-el2.dtso
@@ -20,7 +20,9 @@
 };
 
 &remoteproc_adsp {
-	iommus = <&apps_smmu 0x2000 0x0>;
+	iommus = <&apps_smmu 0x2000 0x0>,
+		<&apps_smmu 0x2060 0x9>,
+		<&apps_smmu 0x2062 0x1>;
 };
 
 &remoteproc_cdsp {

--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -795,6 +795,14 @@
 		#size-cells = <2>;
 		ranges;
 
+		audio_cma_mem: qcom,audio-ml {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1000000>;
+		};
+
 		aop_image_mem: aop-image-region@90800000 {
 			reg = <0x0 0x90800000 0x0 0x60000>;
 			no-map;
@@ -2908,6 +2916,7 @@
 						q6apmdai: dais {
 							compatible = "qcom,q6apm-dais";
 							iommus = <&apps_smmu 0x2001 0x0>;
+							memory-region = <&audio_cma_mem>;
 						};
 					};
 


### PR DESCRIPTION
    The audio ML (machine-learning) offload use case requires a contiguous,
    physically addressable buffer shared with the audio DSP/SPF, and issues
    DMA transactions through additional SMMU stream IDs that are not
    covered by the existing ADSP mapping.

    Add a dedicated reusable shared-dma-pool CMA region (16 MiB, 4 MiB
    aligned) and wire it to the q6apm DAIs node via memory-region. A
    dedicated pool guarantees the alignment and contiguity the DSP expects
    and isolates these allocations from the default CMA region.

    Under the EL2 (Gunyah/hypervisor) configuration the SMMU is fully
    enforcing, so the ML transactions are otherwise blocked and faulted:

     arm-smmu 15000000.iommu: Blocked unknown Stream ID 0x2060
     arm-smmu 15000000.iommu: Blocked unknown Stream ID 0x2062

    Add the ML-related stream IDs (0x3060 mask 0x9, 0x3062 mask 0x1) to the
    remoteproc_adsp iommus property in the EL2 overlay so these buffers are
    translated by the SMMU instead of being rejected.