### PR TITLE
FROMLIST: Revert "clk: qcom: regmap-phy-mux: Rework the implementation"

### DIFF
--- a/drivers/clk/qcom/clk-regmap-phy-mux.c
+++ b/drivers/clk/qcom/clk-regmap-phy-mux.c
@@ -15,66 +15,48 @@
 #define PHY_MUX_PHY_SRC		0
 #define PHY_MUX_REF_SRC		2
 
-#define XO_RATE			19200000UL
-
 static inline struct clk_regmap_phy_mux *to_clk_regmap_phy_mux(struct clk_regmap *clkr)
 {
 	return container_of(clkr, struct clk_regmap_phy_mux, clkr);
 }
 
-static unsigned long phy_mux_recalc_rate(struct clk_hw *hw, unsigned long parent_rate)
+static int phy_mux_is_enabled(struct clk_hw *hw)
 {
 	struct clk_regmap *clkr = to_clk_regmap(hw);
 	struct clk_regmap_phy_mux *phy_mux = to_clk_regmap_phy_mux(clkr);
-	u32 val;
+	unsigned int val;
 
 	regmap_read(clkr->regmap, phy_mux->reg, &val);
+	val = FIELD_GET(PHY_MUX_MASK, val);
 
-	switch (FIELD_GET(PHY_MUX_MASK, val)) {
-	case PHY_MUX_PHY_SRC:
-		return ULONG_MAX;
-	case PHY_MUX_REF_SRC:
-		return XO_RATE;
-	default:
-		return 0;
-	}
+	WARN_ON(val != PHY_MUX_PHY_SRC && val != PHY_MUX_REF_SRC);
+
+	return val == PHY_MUX_PHY_SRC;
 }
 
-static int phy_mux_determine_rate(struct clk_hw *hw, struct clk_rate_request *req)
-{
-	if (req->rate == XO_RATE || req->rate == ULONG_MAX)
-		return 0;
-
-	return -EINVAL;
-}
-
-static int phy_mux_set_rate(struct clk_hw *hw, unsigned long rate, unsigned long parent_rate)
+static int phy_mux_enable(struct clk_hw *hw)
 {
 	struct clk_regmap *clkr = to_clk_regmap(hw);
 	struct clk_regmap_phy_mux *phy_mux = to_clk_regmap_phy_mux(clkr);
-	u32 val;
 
-	switch (rate) {
-	case XO_RATE:
-		val = PHY_MUX_REF_SRC;
-		break;
-	case ULONG_MAX:
-		val = PHY_MUX_PHY_SRC;
-		break;
-	default:
-		return -EINVAL;
-	}
+	return regmap_update_bits(clkr->regmap, phy_mux->reg,
+				  PHY_MUX_MASK,
+				  FIELD_PREP(PHY_MUX_MASK, PHY_MUX_PHY_SRC));
+}
+
+static void phy_mux_disable(struct clk_hw *hw)
+{
+	struct clk_regmap *clkr = to_clk_regmap(hw);
+	struct clk_regmap_phy_mux *phy_mux = to_clk_regmap_phy_mux(clkr);
 
 	regmap_update_bits(clkr->regmap, phy_mux->reg,
 			   PHY_MUX_MASK,
-			   FIELD_PREP(PHY_MUX_MASK, val));
-
-	return 0;
+			   FIELD_PREP(PHY_MUX_MASK, PHY_MUX_REF_SRC));
 }
 
 const struct clk_ops clk_regmap_phy_mux_ops = {
-	.recalc_rate = phy_mux_recalc_rate,
-	.determine_rate = phy_mux_determine_rate,
-	.set_rate = phy_mux_set_rate,
+	.enable = phy_mux_enable,
+	.disable = phy_mux_disable,
+	.is_enabled = phy_mux_is_enabled,
 };
 EXPORT_SYMBOL_GPL(clk_regmap_phy_mux_ops);


### PR DESCRIPTION
This reverts commit e108373c54fbc844b7f541c6fd7ecb31772afd3c.

This has been reported to break PCIe on at least SM8350 and Eliza platforms. I had originally tested this on Hamoa (X1E) where there were no adverse effects. It's highly likely that this stems from a difference in how the bootloader configures the clocks.

Revert the offending change to fix the issue in the immediate, with the intent to revisit it in the upcoming cycle.

Reported-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
Reported-by: Abel Vesa <abel.vesa@oss.qualcomm.com>

Fixes: e108373c54fb ("clk: qcom: regmap-phy-mux: Rework the implementation")
Closes: https://lore.kernel.org/all/c675lcfptr4xgg4hcjp66unmuozgsvgwvtymh7on6jcipjrdw7@jy4h7fkwqwjg/
Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>