### PR TITLE
FROMGIT: power: sequencing: pwrseq-pcie-m2: Add QCC2072 BT PCI device ID

### DIFF
--- a/drivers/power/sequencing/pwrseq-pcie-m2.c
+++ b/drivers/power/sequencing/pwrseq-pcie-m2.c
@@ -190,6 +190,8 @@ static const struct pci_device_id pwrseq_m2_pci_ids[] = {
 	  .driver_data = (kernel_ulong_t)"qcom,wcn6855-bt" },
 	{ PCI_DEVICE(PCI_VENDOR_ID_QCOM, 0x1107),
 	  .driver_data = (kernel_ulong_t)"qcom,wcn7850-bt" },
+	{ PCI_DEVICE(PCI_VENDOR_ID_QCOM, 0x1112),
+	  .driver_data = (kernel_ulong_t)"qcom,qcc2072-bt" },
 	{ } /* Sentinel */
 };
 


### PR DESCRIPTION
Add the Qualcomm QCC2072 Bluetooth device (PCI ID 0x1112) to the pwrseq_m2_pci_ids table so the M.2 power sequencer can create the serdev node for its BT interface on enumeration.


Link: https://patch.msgid.link/20260703-eliza_evk-v1-3-7624440bd76d@oss.qualcomm.com