### PR TITLE
Remoteproc : eliza: cdsp support

### DIFF
--- a/Documentation/devicetree/bindings/remoteproc/qcom,milos-pas.yaml
+++ b/Documentation/devicetree/bindings/remoteproc/qcom,milos-pas.yaml
@@ -16,7 +16,6 @@ description:
 properties:
   compatible:
     enum:
-      - qcom,eliza-adsp-pas
       - qcom,milos-adsp-pas
       - qcom,milos-cdsp-pas
       - qcom,milos-mpss-pas
@@ -88,7 +87,6 @@ allOf:
       properties:
         compatible:
           enum:
-            - qcom,eliza-adsp-pas
             - qcom,milos-adsp-pas
             - qcom,milos-cdsp-pas
     then:
@@ -109,7 +107,6 @@ allOf:
         compatible:
           contains:
             enum:
-              - qcom,eliza-adsp-pas
               - qcom,milos-adsp-pas
     then:
       properties:

--- a/Documentation/devicetree/bindings/remoteproc/qcom,sm8550-pas.yaml
+++ b/Documentation/devicetree/bindings/remoteproc/qcom,sm8550-pas.yaml
@@ -29,6 +29,7 @@ properties:
           - qcom,x1e80100-cdsp-pas
       - items:
           - enum:
+              - qcom,eliza-adsp-pas
               - qcom,glymur-adsp-pas
               - qcom,hawi-adsp-pas
               - qcom,kaanapali-adsp-pas
@@ -132,6 +133,7 @@ allOf:
         compatible:
           contains:
             enum:
+              - qcom,eliza-adsp-pas
               - qcom,glymur-adsp-pas
               - qcom,glymur-cdsp-pas
               - qcom,hawi-adsp-pas
@@ -228,6 +230,7 @@ allOf:
         compatible:
           contains:
             enum:
+              - qcom,eliza-adsp-pas
               - qcom,sm8550-adsp-pas
               - qcom,sm8650-adsp-pas
               - qcom,x1e80100-adsp-pas

--- a/Documentation/devicetree/bindings/remoteproc/qcom,sm8550-pas.yaml
+++ b/Documentation/devicetree/bindings/remoteproc/qcom,sm8550-pas.yaml
@@ -17,6 +17,7 @@ properties:
   compatible:
     oneOf:
       - enum:
+          - qcom,eliza-cdsp-pas
           - qcom,sdx75-mpss-pas
           - qcom,sm8550-adsp-pas
           - qcom,sm8550-cdsp-pas
@@ -169,6 +170,7 @@ allOf:
         compatible:
           contains:
             enum:
+              - qcom,eliza-cdsp-pas
               - qcom,sm8750-cdsp-pas
     then:
       properties:
@@ -282,6 +284,25 @@ allOf:
           items:
             - const: cx
             - const: mxc
+            - const: nsp
+
+  - if:
+      properties:
+        compatible:
+          contains:
+            enum:
+              - qcom,eliza-cdsp-pas
+    then:
+      properties:
+        power-domains:
+          items:
+            - description: CX power domain
+            - description: MX power domain
+            - description: NSP power domain
+        power-domain-names:
+          items:
+            - const: cx
+            - const: mx
             - const: nsp
 
 unevaluatedProperties: false

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -1716,8 +1716,34 @@ static const struct qcom_pas_data glymur_soccp_resource = {
 	.needs_tzmem = true,
 };
 
+static const struct qcom_pas_data eliza_cdsp_resource = {
+	.crash_reason_smem = 601,
+	.firmware_name = "cdsp.mbn",
+	.dtb_firmware_name = "cdsp_dtb.mbn",
+	.pas_id = 18,
+	.dtb_pas_id = 0x25,
+	.minidump_id = 7,
+	.auto_boot = true,
+	.proxy_pd_names = (char*[]){
+		"cx",
+		"mx",
+		"nsp",
+		NULL
+	},
+	.load_state = "cdsp",
+	.ssr_name = "cdsp",
+	.sysmon_name = "cdsp",
+	.ssctl_id = 0x17,
+	.smem_host_id = 5,
+	.region_assign_idx = 2,
+	.region_assign_count = 1,
+	.region_assign_shared = true,
+	.region_assign_vmid = QCOM_SCM_VMID_CDSP,
+};
+
 static const struct of_device_id qcom_pas_of_match[] = {
 	{ .compatible = "qcom,eliza-adsp-pas", .data = &sm8550_adsp_resource },
+	{ .compatible = "qcom,eliza-cdsp-pas", .data = &eliza_cdsp_resource },
 	{ .compatible = "qcom,glymur-soccp-pas", .data = &glymur_soccp_resource },
 	{ .compatible = "qcom,kaanapali-soccp-pas", .data = &kaanapali_soccp_resource },
 	{ .compatible = "qcom,milos-adsp-pas", .data = &sm8550_adsp_resource },


### PR DESCRIPTION
commit c74275c1c55c9655fd322863c4fe1b157723e73e (HEAD -> remoteproc-abel, my-pub-ktopic/remoteproc-abel)
Author: Abel Vesa <abel.vesa@oss.qualcomm.com>
Date:   Tue Jul 21 17:19:58 2026 +0300

    FROMLIST: remoteproc: qcom: pas: Add Eliza CDSP support

    Add dedicated driver data for the Eliza CDSP remote processor. It looks
    almost the same as for Milos, except Eliza needs region assign.
    Tie the new driver data to the Eliza specific compatible.

    Link: https://lore.kernel.org/all/20260721-remoteproc-eliza-cdsp-v3-2-557b5d02fdd9@oss.qualcomm.com/
    Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
    Signed-off-by: Abel Vesa <abel.vesa@oss.qualcomm.com>

commit 07e32b5e182c4e8c52c0c859d79ce83e3681435a
Author: Abel Vesa <abel.vesa@oss.qualcomm.com>
Date:   Tue Jul 21 17:19:57 2026 +0300

    FROMLIST: dt-bindings: remoteproc: qcom,sm8550-pas: Add Eliza CDSP compatible

    Document compatible string for the CDSP Peripheral Authentication Service
    on the Eliza SoC. It is not compatible with any other.

    Link: https://lore.kernel.org/all/20260721-remoteproc-eliza-cdsp-v3-1-557b5d02fdd9@oss.qualcomm.com/
    Signed-off-by: Abel Vesa <abel.vesa@oss.qualcomm.com>

commit 36db9277106c3baa2f3b29102304300acfb2a7cf
Author: Abel Vesa <abel.vesa@oss.qualcomm.com>
Date:   Tue Jul 21 14:35:07 2026 +0300

    FROMLIST: dt-bindings: remoteproc: qcom,milos-pas: Move Eliza ADSP to SM8550 schema

    The ADSP PAS found on Eliza SoC looks fully compatible with SM8750, which
    can fallback to SM8550 except for the extra interrupt ("shutdown-ack").

    So document its bindings in the SM8550 schema instead.

    Link: https://lore.kernel.org/all/20260721-dts-qcom-eliza-fix-adsp-binding-v1-1-3a0b03af2ec7@oss.qualcomm.com/
    Fixes: 7cf2f07f949c ("dt-bindings: remoteproc: qcom,milos-pas: Document Eliza ADSP")
    Signed-off-by: Abel Vesa <abel.vesa@oss.qualcomm.com>
