### PR TITLE
FROMLIST: arm64: dts: qcom: qcm2290: Do not mark MPM as power domain

### DIFF
--- a/arch/arm64/boot/dts/qcom/agatti.dtsi
+++ b/arch/arm64/boot/dts/qcom/agatti.dtsi
@@ -205,7 +205,6 @@
 
 		cluster_pd: power-domain-cpu-cluster {
 			#power-domain-cells = <0>;
-			power-domains = <&mpm>;
 			domain-idle-states = <&cluster_sleep>;
 		};
 	};
@@ -281,7 +280,6 @@
 			mboxes = <&apcs_glb 1>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
-			#power-domain-cells = <0>;
 			interrupt-parent = <&intc>;
 			qcom,mpm-pin-count = <96>;
 			qcom,mpm-pin-map = <2 275>,  /* TSENS0 uplow */


### PR DESCRIPTION
FROMLIST: arm64: dts: qcom: qcm2290: Do not mark MPM as power domain
Do not mark MPM device as power domain since it leads to idle-states init
failure because of probe dependencies.

CPU cluster power domain node is kept disabled and hence CPU cluster will
never power collapse. Do not register MPM under it in this case.

Link: https://lore.kernel.org/lkml/20260713-b4-shikra_lpm_addition-v1-6-3d858df2cbbf@oss.qualcomm.com

CRs-fixed: 4577603