### PR TITLE
pinctrl: qcom: Update summary intr target proc bits width for Shikra

### DIFF
--- a/drivers/pinctrl/qcom/pinctrl-shikra.c
+++ b/drivers/pinctrl/qcom/pinctrl-shikra.c
@@ -44,7 +44,7 @@
 		.intr_status_bit = 0,		\
 		.intr_wakeup_enable_bit = 7,	\
 		.intr_wakeup_present_bit = 6,	\
-`		.intr_target_width = 4,         \
+		.intr_target_width = 4,         \
 		.intr_target_bit = 8,		\
 		.intr_target_kpss_val = 3,	\
 		.intr_raw_status_bit = 4,	\


### PR DESCRIPTION
Update correct width for the bit field.
This bit field decides the target proc which received summary intr.

Remove a stray backtick before .intr_target_width that was breaking compilation.


CRs-Fixed: 4609218