### PR TITLE
arm64: dts: qcom: shikra: Update rpm-stats compatible to SoC specific

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -1591,7 +1591,7 @@
 		};
 
 		sram@4690000 {
-			compatible = "qcom,rpm-stats";
+			compatible = "qcom,shikra-rpm-stats", "qcom,rpm-stats";
 			reg = <0x0 0x04690000 0x0 0x14000>;
 		};
 


### PR DESCRIPTION
FROMLIST: arm64: dts: qcom: shikra: Update rpm-stats compatible to SoC specific

A generic "qcom,rpm-stats" compatible only reads stats for SoC level LPM stats like vmin and vlow.

Shikra SoC specific compatible allows reading individual subsystem level LPM stats along with SoC level LPM stats. Change it.

Keep "qcom,rpm-stats" as fallback compatible.

Link: https://lore.kernel.org/r/20260713-shikra_stats-v3-3-4be17121729d@oss.qualcomm.com