### PR TITLE
qcs6490: Enable BCL sensor node

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm7250b.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm7250b.dtsi
@@ -89,6 +89,15 @@
 			status = "disabled";
 		};
 
+		sensor@1d00 {
+			compatible = "qcom,pm7250b-bcl";
+			reg = <0x1d00>;
+			interrupts = <PM7250B_SID 0x1d 0x0 IRQ_TYPE_EDGE_RISING>,
+				     <PM7250B_SID 0x1d 0x1 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "max-min",
+					  "critical";
+		};
+
 		pm7250b_temp: temp-alarm@2400 {
 			compatible = "qcom,spmi-temp-alarm";
 			reg = <0x2400>;

--- a/arch/arm64/boot/dts/qcom/pm7250b.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm7250b.dtsi
@@ -201,16 +201,6 @@
 			interrupt-controller;
 			#interrupt-cells = <2>;
 		};
-
-		sensor@1d00 {
-			compatible = "qcom,pm7250b-bcl", "qcom,bcl-v1";
-			reg = <0x1d00>;
-			interrupts = <PM7250B_SID 0x1d 0x0 IRQ_TYPE_EDGE_RISING>,
-				     <PM7250B_SID 0x1d 0x1 IRQ_TYPE_EDGE_RISING>;
-			interrupt-names = "bcl-max-min",
-					  "bcl-critical";
-			overcurrent-thresholds-milliamp = <5500 6000>;
-		};
 	};
 
 	pmic@PM7250B_SID1 {

--- a/arch/arm64/boot/dts/qcom/pm8350c.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8350c.dtsi
@@ -20,6 +20,15 @@
 			#thermal-sensor-cells = <0>;
 		};
 
+		sensor@4700 {
+			compatible = "qcom,pm8350c-bcl";
+			reg = <0x4700>;
+			interrupts = <0x2 0x47 0x0 IRQ_TYPE_EDGE_RISING>,
+				     <0x2 0x47 0x1 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "max-min",
+					  "critical";
+		};
+
 		pm8350c_gpios: gpio@8800 {
 			compatible = "qcom,pm8350c-gpio", "qcom,spmi-gpio";
 			reg = <0x8800>;
@@ -41,6 +50,7 @@
 			#pwm-cells = <2>;
 			status = "disabled";
 		};
+
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/pm8350c.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8350c.dtsi
@@ -41,15 +41,6 @@
 			#pwm-cells = <2>;
 			status = "disabled";
 		};
-
-		sensor@4700 {
-			compatible = "qcom,pm8350c-bcl", "qcom,bcl-v2";
-			reg = <0x4700>;
-			interrupts = <0x2 0x47 0x0 IRQ_TYPE_EDGE_RISING>,
-				     <0x2 0x47 0x1 IRQ_TYPE_EDGE_RISING>;
-			interrupt-names = "bcl-max-min",
-					  "bcl-critical";
-		};
 	};
 };
 


### PR DESCRIPTION
Revert the existing changes and upadted as per BCL v2 patch series.
