### PR TITLE
arm64: dts: qcom: kodiak-el2: Add venus firmware sub node

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
@@ -35,7 +35,11 @@
 };
 
 &venus {
-	status = "disabled";
+	status = "okay";
+
+	video-firmware {
+		iommus = <&apps_smmu 0x21a2 0x0>;
+	};
 };
 
 &watchdog {


### PR DESCRIPTION
A dedicated firmware sub-device is required to map the firmware region to the device's IOMMU mapped stream ID, which is the firmware stream ID, in order to boot the Iris firmware when no hypervisor is present. Enable venus and add the video-firmware sub-device with its IOMMU stream ID for EL2 boot on Kodiak.

Pending patch related to KVM. the below is the JIRA.
Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109