### PR TITLE
WORKAROUND: arm64: dts: qcom: Disable usb hs controller on Glymur CRD

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
@@ -643,18 +643,6 @@
 		#phy-cells = <0>;
 	};
 
-	ptn3222_1: redriver@47 {
-		compatible = "nxp,ptn3222";
-		reg = <0x47>;
-
-		reset-gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
-
-		vdd3v3-supply = <&vreg_l8b_e0_1p50>;
-		vdd1v8-supply = <&vreg_l15b_e0_1p8>;
-
-		#phy-cells = <0>;
-	};
-
 	pm8010: pmic@8 {
 		compatible = "qcom,pm8008";
 		reg = <0x8>;
@@ -1401,19 +1389,6 @@
 
 &usb_1_qmpphy_out {
 	remote-endpoint = <&pmic_glink_ss_in1>;
-};
-
-&usb_hs {
-	status = "okay";
-};
-
-&usb_hs_phy {
-	vdd-supply = <&vreg_l2h_e0_0p72>;
-	vdda12-supply = <&vreg_l4h_e0_1p2>;
-
-	phys = <&ptn3222_1>;
-
-	status = "okay";
 };
 
 &usb_mp {


### PR DESCRIPTION
On Glymur, there is an issue while working with the FP sensor connected to USB Hs only controller. The issue is as follows:

1) During boot, the usb controller initialises fine, but an error stating that the descriptor read from FP sensor failed and hence the controller is in an unknown state with failed enumeration of FP sensor.

2) At this point, the problem may be resource voting, but if unbind and rebind is done on the controller, enumeration is fine. All resources were thorughly checked and also schematic was checked to ensure that no GPIOs (if any) are left un-initialised. But resources seem to be fine.

3) When in this state, if we try to enter system suspend, GDSC too gets off, and also on resume we see that usb controller goes dead. And further attempts to enter suspend are gated by this dead controller.

4) If we re-bind controller on boot and then let enumration be successful, and then enter suspend, we see a SMMU crash on resume.

On upstream code however, enumeration is fine on every reboot.

This suspend-resume behavior is gating XO SD and hence disable it on CRD.