### PR TITLE
FROMLIST: drm/msm/dp: add .shutdown to mask HPD IRQ before system shutdown

### DIFF
--- a/drivers/gpu/drm/msm/dp/dp_display.c
+++ b/drivers/gpu/drm/msm/dp/dp_display.c
@@ -1414,6 +1414,14 @@ static void msm_dp_display_remove(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 }
 
+static void msm_dp_display_shutdown(struct platform_device *pdev)
+{
+	struct msm_dp_display_private *dp = dev_get_dp_display_private(&pdev->dev);
+
+	disable_irq(dp->irq);
+	synchronize_irq(dp->irq);
+}
+
 static int msm_dp_pm_runtime_suspend(struct device *dev)
 {
 	struct msm_dp_display_private *dp = dev_get_dp_display_private(dev);
@@ -1460,6 +1468,7 @@ static const struct dev_pm_ops msm_dp_pm_ops = {
 static struct platform_driver msm_dp_display_driver = {
 	.probe  = msm_dp_display_probe,
 	.remove = msm_dp_display_remove,
+	.shutdown = msm_dp_display_shutdown,
 	.driver = {
 		.name = "msm-dp-display",
 		.of_match_table = msm_dp_dt_match,


### PR DESCRIPTION
On reboot, a late DP hot-plug-detect (HPD) IRQ can fire after apps_smmu has already disabled translation for the display subsystem, causing the HPD thread to kick off a new modeset that drives DPU/DP hardware and DMA through a stale IOMMU mapping.

DPU's own .shutdown disables all CRTCs first, but a pending HPD IRQ thread wakes up afterwards, reads the DPCD, and fires an unsolicited hotplug event that triggers a second atomic commit turning the display back on -- right as the IOMMU is disabling translation:

systemd-shutdown[1]: Rebooting.
msm_dpu: drm_atomic_commit: committing (shutdown disabling CRTCs)
arm-smmu 3da0000.iommu: disabling translation
msm_dpu: drm_dp_read_dpcd_caps (late HPD IRQ thread wakes up)
msm_dpu: drm_sysfs_connector_hotplug_event: DP-1 hotplug event
msm_dpu: drm_client_modeset_probe: DP-1 found preferred mode
msm_dpu: drm_atomic_commit: committing (unsolicited, re-enables display)
dpu_crtc_commit_kickoff: crtc94 first commit
arm-smmu 15200000.iommu: disabling translation

Mask and flush the IRQ in .shutdown so no HPD event can retrigger a modeset once shutdown has started. Reported on lemans-evk and monaco-evk during reboot stress testing.

Link: https://lore.kernel.org/all/20260717-dpshutdown-v1-1-b062c2f7dfb1@oss.qualcomm.com/

CRs-Fixed: 4573119