### PR TITLE
FROMLIST: arm64: dts: qcom: kaanapali: Enable LLCC/DDR/DDR_QOS DVFS

### DIFF
--- a/arch/arm64/boot/dts/qcom/kaanapali.dtsi
+++ b/arch/arm64/boot/dts/qcom/kaanapali.dtsi
@@ -249,6 +249,20 @@
 				#clock-cells = <1>;
 			};
 		};
+
+		cpucp_scmi: scmi-1 {
+			compatible = "arm,scmi";
+			mboxes = <&cpucp_mbox 0>, <&cpucp_mbox 2>;
+			mbox-names = "tx", "rx";
+			shmem = <&cpucp_scp_lpri0>, <&cpucp_scp_lpri1>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			scmi_vendor: protocol@80 {
+				reg = <0x80>;
+			};
+		};
 	};
 
 	clk_virt: interconnect-0 {
@@ -6545,6 +6559,13 @@
 			#mbox-cells = <1>;
 		};
 
+		cpucp_mbox: mailbox@17620000 {
+			compatible = "qcom,kaanapali-cpucp-mbox", "qcom,x1e80100-cpucp-mbox";
+			reg = <0x0 0x17620000 0x0 0x8000>, <0x0 0x18830000 0x0 0x8000>;
+			interrupts = <GIC_SPI 28 IRQ_TYPE_LEVEL_HIGH>;
+			#mbox-cells = <1>;
+		};
+
 		timer@17810000 {
 			compatible = "arm,armv7-timer-mem";
 			reg = <0x0 0x17810000 0x0 0x1000>;
@@ -6751,6 +6772,26 @@
 						opp-level = <RPMH_REGULATOR_LEVEL_SUPER_TURBO_NO_CPR>;
 					};
 				};
+			};
+		};
+
+		cpucp_sram: sram@1d838000 {
+			compatible = "mmio-sram";
+			reg = <0x0 0x1d838000 0x0 0x400>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ranges = <0x0 0x0 0x1d838000 0x400>;
+
+			cpucp_scp_lpri0: scp-sram-section@0 {
+				compatible = "arm,scmi-shmem";
+				reg = <0x0 0x200>;
+			};
+
+			cpucp_scp_lpri1: scp-sram-section@200 {
+				compatible = "arm,scmi-shmem";
+				reg = <0x200 0x200>;
 			};
 		};
 


### PR DESCRIPTION
On Qualcomm Kaanapali SoCs, the memlat governor and the mechanism for controlling the LLCC and DDR/DDR_QOS frequencies run on the CPU Control Processor (CPUCP) and are exposed via the QCOM SCMI Generic Extension protocol. Add the CPUCP mailbox, the SCMI shared-memory regions and the CPUCP SCMI instance (scmi-1) with the Qualcomm vendor protocol@80 required for the QCOM SCMI Generic Extension protocol to probe and get functional bus DVFS on Kaanapali.




Link: https://lore.kernel.org/r/20260724-rfc_v8_scmi_memlat-v1-10-cb732bcff1f4@oss.qualcomm.com