### PR TITLE
arm64: dts: qcom: talos-lyra-evk: Add GPIO expander support

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
@@ -13,6 +13,31 @@
 	chassis-type = "embedded";
 };
 
+&i2c5 {
+	status = "okay";
+
+	expander0: gpio@20 {
+		compatible = "kinetic,kts1622", "nxp,pca9555";
+		reg = <0x20>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	expander1: gpio@21 {
+		compatible = "kinetic,kts1622", "nxp,pca9555";
+		reg = <0x21>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	expander2: gpio@38 {
+		compatible = "ti,tca9538";
+		reg = <0x38>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
 &pon_pwrkey {
 	status = "okay";
 };


### PR DESCRIPTION
  Add three I2C GPIO expander devices on the i2c5 bus of the Talos
  Lyra EVK carrier board:

  - expander0 (gpio@20): Kinetic KTS1622 16-bit I2C GPIO expander
    (compatible with NXP PCA9555)
  - expander1 (gpio@21): Kinetic KTS1622 16-bit I2C GPIO expander
    (compatible with NXP PCA9555)
  - expander2 (gpio@38): TI TCA9538 8-bit I2C GPIO expander
