### PR TITLE
FROMLIST: dt-bindings: arm: qcom,coresight-ctcu: Add Shikra

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom,coresight-ctcu.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom,coresight-ctcu.yaml
@@ -32,6 +32,7 @@ properties:
               - qcom,glymur-ctcu
               - qcom,kaanapali-ctcu
               - qcom,qcs8300-ctcu
+              - qcom,shikra-ctcu
               - qcom,sm8750-ctcu
               - qcom,x1e80100-ctcu
           - const: qcom,sa8775p-ctcu


### PR DESCRIPTION
The CTCU device for the Shikra shares the same configurations as SA8775p. Add a fallback to enable the CTCU for the Shikra to utilize the compatible of the SA8775p.

Link: https://lore.kernel.org/all/20260723-add-coresight-nodes-for-shikra-v5-1-fd5494471b36@oss.qualcomm.com/
Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>