### PR TITLE
FROMLIST: PCI: Allow D3 for native Hotplug capable Root Ports on DT p…

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -3031,11 +3031,11 @@ bool pci_bridge_d3_possible(struct pci_dev *bridge)
 			return true;
 
 		/*
-		 * Hotplug ports handled natively by the OS were not validated
-		 * by vendors for runtime D3 at least until 2018 because there
-		 * was no OS support.
+		 * Do not allow D3 for native Hotplug ports on non-DT platforms
+		 * as they were not validated by vendors for runtime D3 at least
+		 * until 2018 because there was no OS support.
 		 */
-		if (bridge->is_pciehp)
+		if (bridge->is_pciehp && !of_have_populated_dt())
 			return false;
 
 		if (dmi_check_system(bridge_d3_blacklist))


### PR DESCRIPTION
…latforms

Commit eb3b5bf1a88d ("PCI: Whitelist native hotplug ports for runtime D3"), prevented native Hotplug capable Root Ports from entering D3 citing issues on old Intel SkyLake Xeon-SP platform.

But there is no reason to restrict D3 for native Hotplug capable Root Ports on DT platforms. We recently enabled D3 on non-Hotplug capable Root Ports on non-x86 platforms (specifically for DT platforms) in commit a5fb3ff63287 ("PCI: Allow PCI bridges to go to D3Hot on all non-x86"). So do the same for native Hotplug capable Root Ports as well.

To honor the above platform_pci_bridge_d3() check, allow passing this check only for DT platforms, unlike a5fb3ff63287, which used !CONFIG_X86 check.

Link: https://lore.kernel.org/all/20260729071514.859778-1-manivannan.sadhasivam@oss.qualcomm.com/