### PR TITLE
arm64: dts: qcom: monaco-evk: Enable Bluetooth support via M.2 Key E connector

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
@@ -16,7 +16,6 @@
 		ethernet0 = &ethernet0;
 		i2c1 = &i2c1;
 		serial0 = &uart7;
-		serial1 = &uart2;
 		serial2 = &uart6;
 	};
 
@@ -167,29 +166,6 @@
 
 		pinctrl-0 = <&cam2_avdd_2v8_en_default>;
 		pinctrl-names = "default";
-	};
-
-	vreg_dcin_12v: regulator-dcin-12v {
-		compatible = "regulator-fixed";
-
-		regulator-name = "VREG_DCIN_12V";
-		regulator-min-microvolt = <12000000>;
-		regulator-max-microvolt = <12000000>;
-
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	vreg_wcn_3p3: regulator-wcn-3p3 {
-		compatible = "regulator-fixed";
-
-		regulator-name = "VREG_WCN_3P3";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-
-		vin-supply = <&vreg_dcin_12v>;
-
-		regulator-boot-on;
 	};
 };
 
@@ -858,24 +834,6 @@
 		pins = "gpio96";
 		function = "gpio";
 		bias-pull-up;
-	};
-};
-
-&uart2 {
-	status = "okay";
-
-	bluetooth: bluetooth {
-		compatible = "qcom,wcn6855-bt";
-		max-speed = <3200000>;
-
-		vddrfacmn-supply = <&vreg_wcn_3p3>;
-		vddaon-supply = <&vreg_wcn_3p3>;
-		vddwlcx-supply = <&vreg_wcn_3p3>;
-		vddwlmx-supply = <&vreg_wcn_3p3>;
-		vddbtcmx-supply = <&vreg_wcn_3p3>;
-		vddrfa0p8-supply = <&vreg_wcn_3p3>;
-		vddrfa1p2-supply = <&vreg_wcn_3p3>;
-		vddrfa1p8-supply = <&vreg_wcn_3p3>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -11,6 +11,42 @@
 	model = "Qualcomm Technologies, Inc. Monaco EVK";
 	compatible = "qcom,monaco-evk", "qcom,qcs8300";
 
+	aliases {
+		serial1 = &uart2;
+	};
+
+	connector-3 {
+		compatible = "pcie-m2-e-connector";
+		vpcie3v3-supply = <&vreg_wcn_3p3>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				m2_e_pcie_ep: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&pcieport0_ep>;
+				};
+			};
+
+			port@3 {
+				reg = <3>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				m2_e_uart_ep: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&uart2_ep>;
+				};
+			};
+		};
+	};
+
 	/* This comes from a PMIC handled within the SAIL domain */
 	vreg_s2s: vreg-s2s {
 		compatible = "regulator-fixed";
@@ -44,6 +80,10 @@
 	};
 };
 
+&pcieport0_ep {
+	remote-endpoint = <&m2_e_pcie_ep>;
+};
+
 &sdhc_1 {
 	vmmc-supply = <&vreg_l8a>;
 	vqmmc-supply = <&vreg_s2s>;
@@ -53,4 +93,12 @@
 	non-removable;
 
 	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&uart2_ep {
+	remote-endpoint = <&m2_e_uart_ep>;
 };

--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -1262,6 +1262,10 @@
 				power-domains = <&rpmhpd RPMHPD_CX>;
 				operating-points-v2 = <&qup_opp_table>;
 				status = "disabled";
+
+				port {
+					uart2_ep: endpoint {};
+				};
 			};
 
 			i2c3: i2c@98c000 {
@@ -2480,6 +2484,10 @@
 				#size-cells = <2>;
 				ranges;
 				phys = <&pcie0_phy>;
+
+				port {
+					pcieport0_ep: endpoint {};
+				};
 			};
 		};
 

--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -2471,6 +2471,7 @@
 			};
 
 			pcieport0: pcie@0 {
+				compatible = "pciclass,0604";
 				device_type = "pci";
 				reg = <0x0 0x0 0x0 0x0 0x0>;
 				bus-range = <0x01 0xff>;


### PR DESCRIPTION
  The Monaco EVK has a Bluetooth/WiFi module on an M.2 Key E
  card connected via PCIe and UART. Enable Bluetooth support by describing
  the M.2 connector in the device tree.

  Patch 1 adds 'compatible = "pciclass,0604"' to pcieport0 in monaco.dtsi,
  required for the PCI subsystem to associate the DT node with the
  PCI-to-PCI bridge device.

  Patch 2 adds empty graph port/endpoint anchors (pcieport0_ep, uart2_ep)
  to pcieport0 and uart2 in monaco.dts.

  Patch 3 describes the M.2 Key E connector node in monaco-evk.dts, links
  it to PCIe 0 Root Port and UART2, and adds the serial1 = &uart2 alias
  required for the Bluetooth serdev device to enumerate on UART2.

  With this proper M.2 solution in place, the previous Bluetooth workaround
  (FROMLIST: arm64: dts: qcom: monaco-evk: Enable Bluetooth support,
  commit 0879f9141e9d) should be reverted.

  The upstream series:
  https://lore.kernel.org/r/20260729-b4-monaco-evk-m2-v1-v2-0-0548e1dab760@oss.qualcomm.com/

CRs-Fixed: 4610036

