### PR TITLE
QCLINUX: arm64: dts: qcom: shikra: Install camx DTBO overlays

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -600,3 +600,13 @@ dtb-$(CONFIG_ARCH_QCOM) += sm8750-staging.dtbo
 dtb-$(CONFIG_ARCH_QCOM) += kaanapali-staging.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += shikra-staging.dtbo
+
+shikra-cqs-evk-camx-dtbs	:= shikra-cqs-evk.dtb shikra-cqs-evk-camx.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= shikra-cqs-evk-camx.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= shikra-cqs-evk-camx.dtbo
+
+shikra-iqs-evk-camx-dtbs	:= shikra-iqs-evk.dtb shikra-iqs-evk-camx.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= shikra-iqs-evk-camx.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= shikra-iqs-evk-camx.dtbo

--- a/arch/arm64/boot/dts/qcom/shikra-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-camera.dtsi
@@ -1,0 +1,1191 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <dt-bindings/camera/msm-camera.h>
+
+&soc {
+	cam_cpas: qcom,cam-cpas@5c11000 {
+		compatible = "qcom,cam-cpas";
+		label = "cpas";
+		arch-compat = "cpas_top";
+		reg = <0x0 0x5c11000 0x0 0x1000>,
+		      <0x0 0x5c13000 0x0 0x4000>;
+		reg-names = "cam_cpas_top", "cam_camnoc";
+		reg-cam-base = <0x11000 0x13000>;
+		interrupts = <GIC_SPI 159 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "cpas_camnoc";
+		camnoc-axi-min-ib-bw = <3000000000>;
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TOP_AHB_CLK>,
+			 <&gcc GCC_CAMSS_TOP_AHB_CLK_SRC>,
+			 <&gcc GCC_CAMSS_AXI_CLK>,
+			 <&gcc GCC_CAMSS_AXI_CLK_SRC>,
+			 <&gcc GCC_CAMSS_NRT_AXI_CLK>,
+			 <&gcc GCC_CAMSS_RT_AXI_CLK>;
+		clock-names = "gcc_camss_top_ahb_clk",
+			      "gcc_camss_top_ahb_clk_src",
+			      "gcc_camss_axi_clk",
+			      "gcc_camss_axi_clk_src",
+			      "gcc_camss_nrt_axi_clk",
+			      "gcc_camss_rt_axi_clk";
+		clock-rates = <0 0 0 0 0 0>,
+			      <0 19200000 0  19200000 0 0>,
+			      <0 80000000 0 150000000 0 0>,
+			      <0 80000000 0 200000000 0 0>,
+			      <0 80000000 0 300000000 0 0>,
+			      <0 80000000 0 300000000 0 0>,
+			      <0 80000000 0 300000000 0 0>;
+		clock-cntl-level = "suspend", "lowsvs", "svs",
+				   "svs_l1", "nominal", "nominal_l1", "turbo";
+		src-clock-name = "gcc_camss_axi_clk_src";
+		operating-points-v2 = <&cpas_opp_table>;
+		control-camnoc-axi-clk;
+		camnoc-bus-width = <32>;
+		camnoc-axi-clk-bw-margin-perc = <20>;
+		cam-icc-path-names = "cam_ahb";
+		interconnects = <&mem_noc MASTER_AMPSS_M0 0 &config_noc SLAVE_CAMERA_CFG 0>,
+				<&mmrt_virt MASTER_CAMNOC_HF 0 &mc_virt SLAVE_EBI_CH0 0>,
+				<&mmnrt_virt MASTER_CAMNOC_SF 0 &mc_virt SLAVE_EBI_CH0 0>;
+		interconnect-names = "cam_ahb", "cam_hf_0", "cam_sf_0";
+		cam-ahb-num-cases = <7>;
+		cam-ahb-bw-KBps = <0 0>, <0 133333>, <0 150000>, <0 150000>,
+				  <0 300000>, <0 300000>, <0 300000>;
+		vdd-corners = <RPMH_REGULATOR_LEVEL_RETENTION
+			       RPMH_REGULATOR_LEVEL_MIN_SVS
+			       RPMH_REGULATOR_LEVEL_LOW_SVS
+			       RPMH_REGULATOR_LEVEL_LOW_SVS_L1
+			       RPMH_REGULATOR_LEVEL_LOW_SVS_L2
+			       RPMH_REGULATOR_LEVEL_SVS
+			       RPMH_REGULATOR_LEVEL_SVS_L0
+			       RPMH_REGULATOR_LEVEL_SVS_L1
+			       RPMH_REGULATOR_LEVEL_SVS_L2
+			       RPMH_REGULATOR_LEVEL_NOM
+			       RPMH_REGULATOR_LEVEL_NOM_L1
+			       RPMH_REGULATOR_LEVEL_NOM_L2
+			       RPMH_REGULATOR_LEVEL_TURBO
+			       RPMH_REGULATOR_LEVEL_TURBO_L1>;
+		vdd-corner-ahb-mapping = "suspend", "lowsvs", "lowsvs",
+					 "lowsvs", "lowsvs", "svs", "svs_l1", "svs_l1",
+					 "svs_l1", "nominal", "nominal", "nominal",
+					 "turbo", "turbo";
+		client-id-based;
+		client-names = "csiphy0", "csiphy1", "cci0",
+			       "csid0", "csid1", "tfe0",
+			       "tfe1", "ope0", "cam-cdm-intf0",
+			       "cpas-cdm0", "ope-cdm0";
+		cell-index = <0>;
+		status = "okay";
+
+		camera-bus-nodes {
+			level0-nodes {
+				level-index = <0>;
+
+				cpas_cdm0_all_rd: cpas-cdm0-all-rd {
+					cell-index = <0>;
+					node-name = "cpas-cdm0-all-rd";
+					client-name = "cpas-cdm0";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_READ>;
+					parent-node = <&level1_nrt0_rd_wr>;
+				};
+
+				ope_cdm0_all_rd: ope-cdm0-all-rd {
+					cell-index = <1>;
+					node-name = "ope-cdm0-all-rd";
+					client-name = "ope-cdm0";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_READ>;
+					parent-node = <&level1_nrt0_rd_wr>;
+				};
+
+				ope0_all_rd: ope0-all-rd {
+					cell-index = <2>;
+					node-name = "ope0-all-rd";
+					client-name = "ope0";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_READ>;
+					constituent-paths = <CAM_CPAS_PATH_DATA_OPE_RD_IN
+							     CAM_CPAS_PATH_DATA_OPE_RD_REF>;
+					parent-node = <&level1_nrt0_rd_wr>;
+				};
+
+				ope0_all_wr: ope0-all-wr {
+					cell-index = <3>;
+					node-name = "ope0-all-wr";
+					client-name = "ope0";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_WRITE>;
+					constituent-paths = <CAM_CPAS_PATH_DATA_OPE_WR_VID
+							     CAM_CPAS_PATH_DATA_OPE_WR_DISP
+							     CAM_CPAS_PATH_DATA_OPE_WR_REF>;
+					parent-node = <&level1_nrt0_rd_wr>;
+				};
+
+				tfe0_all_wr: tfe0-all-wr {
+					cell-index = <4>;
+					node-name = "tfe0-all-wr";
+					client-name = "tfe0";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_WRITE>;
+					constituent-paths = <CAM_CPAS_PATH_DATA_IFE_RDI0
+							     CAM_CPAS_PATH_DATA_IFE_RDI1
+							     CAM_CPAS_PATH_DATA_IFE_RDI2
+							     CAM_CPAS_PATH_DATA_IFE_RDI3
+							     CAM_CPAS_PATH_DATA_IFE_VID
+							     CAM_CPAS_PATH_DATA_IFE_DISP
+							     CAM_CPAS_PATH_DATA_IFE_STATS>;
+					parent-node = <&level1_rt0_wr>;
+				};
+
+				tfe1_all_wr: tfe1-all-wr {
+					cell-index = <5>;
+					node-name = "tfe1-all-wr";
+					client-name = "tfe1";
+					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_WRITE>;
+					constituent-paths = <CAM_CPAS_PATH_DATA_IFE_RDI0
+							     CAM_CPAS_PATH_DATA_IFE_RDI1
+							     CAM_CPAS_PATH_DATA_IFE_RDI2
+							     CAM_CPAS_PATH_DATA_IFE_RDI3
+							     CAM_CPAS_PATH_DATA_IFE_VID
+							     CAM_CPAS_PATH_DATA_IFE_DISP
+							     CAM_CPAS_PATH_DATA_IFE_STATS>;
+					parent-node = <&level1_rt0_wr>;
+				};
+			};
+
+			level1-nodes {
+				level-index = <1>;
+				camnoc-max-needed;
+
+				level1_nrt0_rd_wr: level1-nrt0-rd-wr {
+					cell-index = <6>;
+					node-name = "level1-nrt0-rd-wr";
+					parent-node = <&level2_nrt0_rd_wr_sum>;
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM_INTERLEAVE>;
+				};
+
+				level1_rt0_wr: level1-rt0-wr {
+					cell-index = <7>;
+					node-name = "level1-rt0-wr";
+					parent-node = <&level2_rt0_rd_wr_sum>;
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM_INTERLEAVE>;
+				};
+			};
+
+			level2-nodes {
+				level-index = <2>;
+
+				level2_nrt0_rd_wr_sum: level2-nrt0-rd-wr-sum {
+					cell-index = <8>;
+					node-name = "level2-nrt0-rd-wr-sum";
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
+					qcom,axi-port-name = "cam_sf_0";
+					qcom,axi-port-mnoc {
+						cam-icc-path-names = "cam_sf_0";
+					};
+				};
+
+				level2_rt0_rd_wr_sum: level2-rt0-rd-wr-sum {
+					cell-index = <9>;
+					node-name = "level2-rt0-rd-wr-sum";
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
+					qcom,axi-port-name = "cam_hf_0";
+					ib-bw-voting-needed;
+					qcom,axi-port-mnoc {
+						cam-icc-path-names = "cam_hf_0";
+					};
+				};
+			};
+		};
+
+		cpas_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-150000000 {
+				opp-hz = /bits/ 64 <150000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-200000000 {
+				opp-hz = /bits/ 64 <200000000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-300000000 {
+				opp-hz = /bits/ 64 <300000000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_cci0: qcom,cci0@5c1b000 {
+		compatible = "qcom,cci", "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x0 0x5c1b000 0x0 0x1000>;
+		reg-names = "cci";
+		reg-cam-base = <0x1b000>;
+		interrupts = <GIC_SPI 206 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "cci0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_CCI_CLK_SRC>,
+			 <&gcc GCC_CAMSS_CCI_0_CLK>;
+		clock-names = "cci_0_clk_src",
+			      "cci_0_clk";
+		clock-rates = <19200000 0>,
+			      <37500000 0>;
+		clock-cntl-level = "lowsvs", "svs";
+		src-clock-name = "cci_0_clk_src";
+		operating-points-v2 = <&cci0_opp_table>;
+		pctrl-idx-mapping = <CCI_MASTER_0 CCI_MASTER_1>;
+		pctrl-map-names = "m0", "m1";
+		pinctrl-names = "m0_active", "m0_suspend",
+				"m1_active", "m1_suspend";
+		pinctrl-0 = <&cci_i2c_scl0_active &cci_i2c_sda0_active>;
+		pinctrl-1 = <&cci_i2c_scl0_suspend &cci_i2c_sda0_suspend>;
+		pinctrl-2 = <&cci_i2c_scl1_active &cci_i2c_sda1_active>;
+		pinctrl-3 = <&cci_i2c_scl1_suspend &cci_i2c_sda1_suspend>;
+		cell-index = <0>;
+		status = "okay";
+
+		cci0_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-37500000 {
+				opp-hz = /bits/ 64 <37500000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+		};
+
+		i2c_freq_custom_cci0: qcom,i2c-custom-mode {
+			hw-thigh = <16>;
+			hw-tlow = <22>;
+			hw-tsu-sto = <17>;
+			hw-tsu-sta = <18>;
+			hw-thd-dat = <16>;
+			hw-thd-sta = <15>;
+			hw-tbuf = <24>;
+			hw-scl-stretch-en = <1>;
+			hw-trdhld = <3>;
+			hw-tsp = <3>;
+			cci-clk-src = <37500000>;
+			status = "okay";
+		};
+
+		i2c_freq_400Khz_cci0: qcom,i2c-fast-mode {
+			hw-thigh = <38>;
+			hw-tlow = <56>;
+			hw-tsu-sto = <40>;
+			hw-tsu-sta = <40>;
+			hw-thd-dat = <22>;
+			hw-thd-sta = <35>;
+			hw-tbuf = <62>;
+			hw-scl-stretch-en = <1>;
+			hw-trdhld = <6>;
+			hw-tsp = <3>;
+			cci-clk-src = <37500000>;
+			status = "okay";
+		};
+
+		i2c_freq_1Mhz_cci0: qcom,i2c-fast-plus-mode {
+			hw-thigh = <16>;
+			hw-tlow = <22>;
+			hw-tsu-sto = <17>;
+			hw-tsu-sta = <18>;
+			hw-thd-dat = <16>;
+			hw-thd-sta = <15>;
+			hw-tbuf = <24>;
+			hw-scl-stretch-en = <1>;
+			hw-trdhld = <3>;
+			hw-tsp = <3>;
+			cci-clk-src = <37500000>;
+			status = "okay";
+		};
+
+		i2c_freq_100Khz_cci0: qcom,i2c-standard-mode {
+			hw-thigh = <201>;
+			hw-tlow = <174>;
+			hw-tsu-sto = <204>;
+			hw-tsu-sta = <231>;
+			hw-thd-dat = <22>;
+			hw-thd-sta = <162>;
+			hw-tbuf = <227>;
+			hw-scl-stretch-en = <0>;
+			hw-trdhld = <6>;
+			hw-tsp = <3>;
+			cci-clk-src = <37500000>;
+			status = "okay";
+		};
+	};
+
+	cam_cpas_cdm: qcom,cpas-cdm0@5c23000 {
+		compatible = "qcom,cam-cpas-cdm2_0";
+		label = "cpas-cdm";
+		reg = <0x0 0x5c23000 0x0 0x400>;
+		reg-names = "cpas-cdm0";
+		reg-cam-base = <0x23000>;
+		interrupts = <GIC_SPI 207 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "cpas-cdm0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TOP_AHB_CLK>;
+		clock-names = "cam_cc_cpas_top_ahb_clk";
+		clock-rates = <19200000>,
+					<80000000>;
+		clock-cntl-level = "lowsvs", "svs";
+		src-clock-name = "cam_cc_cpas_top_ahb_clk";
+		operating-points-v2 = <&cpas_cdm_opp_table>;
+		cdm-client-names = "tfe0", "tfe1";
+		config-fifo;
+		fifo-depths = <64 64 64 64>;
+		cell-index = <0>;
+		status = "okay";
+
+		cpas_cdm_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-80000000 {
+				opp-hz = /bits/ 64 <80000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+		};
+
+	};
+
+	cam_ope_cdm: qcom,ope-cdm0@5c42000 {
+		compatible = "qcom,cam-ope-cdm2_0";
+		label = "ope-cdm";
+		reg = <0x0 0x5c42000 0x0 0x400>;
+		reg-names = "ope-cdm0";
+		reg-cam-base = <0x42000>;
+		interrupts = <GIC_SPI 208 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "ope-cdm0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_OPE_AHB_CLK>,
+			 <&gcc GCC_CAMSS_OPE_CLK_SRC>,
+			 <&gcc GCC_CAMSS_OPE_CLK>;
+		clock-names = "ope_ahb_clk",
+			      "ope_clk_src",
+			      "ope_clk";
+		clock-rates = <19200000 19200000 19200000>,
+			      <171428571 200000000 200000000>,
+			      <171428571 266600000 266600000>,
+			      <240000000 465000000 465000000>,
+			      <240000000 580000000 580000000>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "nominal", "turbo";
+		src-clock-name = "ope_clk_src";
+		cdm-client-names = "ope";
+		operating-points-v2 = <&ope_cdm_opp_table>;
+		config-fifo;
+		fifo-depths = <64 64 64 64>;
+		cell-index = <0>;
+		status = "okay";
+
+		ope_cdm_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-200000000 {
+				opp-hz = /bits/ 64 <200000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-266600000 {
+				opp-hz = /bits/ 64 <266600000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-465000000 {
+				opp-hz = /bits/ 64 <465000000>;
+				required-opps = <&rpmpd_opp_nom>;
+			};
+
+			opp-580000000 {
+				opp-hz = /bits/ 64 <580000000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	ope: qcom,ope@5c42000 {
+		compatible = "qcom,ope";
+		reg = <0x0 0x5c42000 0x0 0x400>,
+		      <0x0 0x5c42400 0x0 0x200>,
+		      <0x0 0x5c42600 0x0 0x200>,
+		      <0x0 0x5c42800 0x0 0x4400>,
+		      <0x0 0x5c46c00 0x0 0x190>,
+		      <0x0 0x5c46d90 0x0 0xa00>;
+		reg-names = "ope_cdm",
+			    "ope_top",
+			    "ope_qos",
+			    "ope_pp",
+			    "ope_bus_rd",
+			    "ope_bus_wr";
+		reg-cam-base = <0x42000 0x42400 0x42600 0x42800 0x46c00 0x46d90>;
+		interrupts = <GIC_SPI 209 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "ope";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_OPE_AHB_CLK_SRC>,
+			 <&gcc GCC_CAMSS_OPE_AHB_CLK>,
+			 <&gcc GCC_CAMSS_OPE_CLK_SRC>,
+			 <&gcc GCC_CAMSS_OPE_CLK>;
+		clock-names = "ope_ahb_clk_src",
+			      "ope_ahb_clk",
+			      "ope_clk_src",
+			      "ope_clk";
+		clock-rates = <19200000 0 19200000 0>,
+			      <171428571 0 200000000 0>,
+			      <171428571 0 266600000 0>,
+			      <240000000 0 465000000 0>,
+			      <240000000 0 580000000 0>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "nominal", "turbo";
+		src-clock-name = "ope_clk_src";
+		operating-points-v2 = <&ope_opp_table>;
+		clock-control-debugfs = "true";
+		cam_hw_pid = <1 0>;
+		cell-index = <0>;
+		status = "okay";
+
+		ope_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-200000000 {
+				opp-hz = /bits/ 64 <200000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-266600000 {
+				opp-hz = /bits/ 64 <266600000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-465000000 {
+				opp-hz = /bits/ 64 <465000000>;
+				required-opps = <&rpmpd_opp_nom>;
+			};
+
+			opp-580000000 {
+				opp-hz = /bits/ 64 <580000000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_csiphy0: qcom,csiphy0@5c52000 {
+		compatible = "qcom,csiphy-v2.0.0", "qcom,csiphy";
+		reg = <0x0 0x5c52000 0x0 0x1000>;
+		reg-names = "csiphy";
+		reg-cam-base = <0x52000>;
+		interrupts = <GIC_SPI 72 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "csiphy0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		csi-vdd-1p2-supply = <&pm8150_l11>;
+		csi-vdd-1p8-supply = <&pm8150_l12>;
+		regulator-names = "csi-vdd-1p2", "csi-vdd-1p8";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1200000 1800000>;
+		rgltr-max-voltage = <1200000 1800000>;
+		rgltr-load-current = <1200000 300000>;
+		shared-clks = <1 0 0 0>;
+		clocks = <&gcc GCC_CAMSS_TFE_CPHY_RX_CLK_SRC>,
+			 <&gcc GCC_CAMSS_CPHY_0_CLK>,
+			 <&gcc GCC_CAMSS_CSI0PHYTIMER_CLK_SRC>,
+			 <&gcc GCC_CAMSS_CSI0PHYTIMER_CLK>;
+		clock-names = "cphy_rx_clk_src",
+			      "csiphy0_clk",
+			      "csi0phytimer_clk_src",
+			      "csi0phytimer_clk";
+		src-clock-name = "csi0phytimer_clk_src";
+		clock-cntl-level = "lowsvs", "svs", "nominal", "turbo";
+		clock-rates = <19200000 0 19200000 0>,
+			      <240000000 0 200000000 0>,
+			      <341330000 0 268800000 0>,
+			      <384000000 0 268800000 0>;
+		operating-points-v2 = <&csiphy0_opp_table>;
+		cell-index = <0>;
+		status = "okay";
+
+		csiphy0_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-200000000 {
+				opp-hz = /bits/ 64 <200000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-268800000 {
+				opp-hz = /bits/ 64 <268800000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_csiphy1: qcom,csiphy1@5c53000 {
+		compatible = "qcom,csiphy-v2.0.0", "qcom,csiphy";
+		reg = <0x0 0x5c53000 0x0 0x1000>;
+		reg-names = "csiphy";
+		reg-cam-base = <0x53000>;
+		interrupts = <GIC_SPI 73 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "csiphy1";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		csi-vdd-1p2-supply = <&pm8150_l11>;
+		csi-vdd-1p8-supply = <&pm8150_l12>;
+		regulator-names = "csi-vdd-1p2", "csi-vdd-1p8";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1200000 1800000>;
+		rgltr-max-voltage = <1200000 1800000>;
+		rgltr-load-current = <1200000 300000>;
+		shared-clks = <1 0 0 0>;
+		clocks = <&gcc GCC_CAMSS_TFE_CPHY_RX_CLK_SRC>,
+			 <&gcc GCC_CAMSS_CPHY_1_CLK>,
+			 <&gcc GCC_CAMSS_CSI1PHYTIMER_CLK_SRC>,
+			 <&gcc GCC_CAMSS_CSI1PHYTIMER_CLK>;
+		clock-names = "cphy_rx_clk_src",
+			      "csiphy1_clk",
+			      "csi1phytimer_clk_src",
+			      "csi1phytimer_clk";
+		src-clock-name = "csi1phytimer_clk_src";
+		clock-cntl-level = "lowsvs", "svs", "nominal", "turbo";
+		clock-rates = <19200000 0 19200000 0>,
+			      <240000000 0 200000000 0>,
+			      <341330000 0 268800000 0>,
+			      <384000000 0 268800000 0>;
+		operating-points-v2 = <&csiphy1_opp_table>;
+		cell-index = <1>;
+		status = "okay";
+
+		csiphy1_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-200000000 {
+				opp-hz = /bits/ 64 <200000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-268800000 {
+				opp-hz = /bits/ 64 <268800000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_tfe_csid0: qcom,tfe-csid0@5c6e000 {
+		compatible = "qcom,csid530";
+		reg = <0x0 0x5c6e000 0x0 0x1000>,
+		      <0x0 0x5c11000 0x0 0x1000>,
+		      <0x0 0x5c13000 0x0 0x4000>;
+		reg-names = "csid", "top", "camnoc";
+		reg-cam-base = <0x6e000 0x11000 0x13000>;
+		interrupts = <GIC_SPI 210 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "csid0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TFE_0_CSID_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_0_CSID_CLK>,
+			 <&gcc GCC_CAMSS_TFE_CPHY_RX_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_0_CPHY_RX_CLK>,
+			 <&gcc GCC_CAMSS_TFE_0_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_0_CLK>;
+		clock-names = "tfe_csid_clk_src",
+			      "tfe_csid_clk",
+			      "cphy_rx_clk_src",
+			      "tfe_cphy_rx_clk",
+			      "tfe_clk_src",
+			      "tfe_clk";
+		clock-rates = <19200000 0 19200000 0 19200000 0>,
+			      <240000000 0 240000000 0 256000000 0>,
+			      <384000000 0 341333333 0 460800000 0>,
+			      <426400000 0 384000000 0 576000000 0>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "turbo";
+		src-clock-name = "tfe_csid_clk_src";
+		operating-points-v2 = <&csid0_opp_table>;
+		clock-control-debugfs = "true";
+		cell-index = <0>;
+		status = "okay";
+
+		csid0_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-240000000 {
+				opp-hz = /bits/ 64 <240000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-384000000 {
+				opp-hz = /bits/ 64 <384000000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-426400000 {
+				opp-hz = /bits/ 64 <426400000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_tfe0: qcom,tfe0@5c6e000 {
+		compatible = "qcom,tfe530";
+		reg = <0x0 0x5c6e000 0x0 0x5000>;
+		reg-names = "tfe0";
+		reg-cam-base = <0x6e000>;
+		interrupts = <GIC_SPI 211 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "tfe0";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TFE_0_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_0_CLK>;
+		clock-names = "tfe_clk_src",
+			      "tfe_clk";
+		clock-rates = <19200000 0>,
+			      <256000000 0>,
+			      <460800000 0>,
+			      <576000000 0>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "turbo";
+		src-clock-name = "tfe_clk_src";
+		operating-points-v2 = <&vfe0_opp_table>;
+		clock-control-debugfs = "true";
+		cam_hw_pid = <4>;
+		cell-index = <0>;
+		status = "okay";
+
+		vfe0_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-256000000 {
+				opp-hz = /bits/ 64 <256000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-460800000 {
+				opp-hz = /bits/ 64 <460800000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-576000000 {
+				opp-hz = /bits/ 64 <576000000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_tfe_csid1: qcom,tfe-csid1@5c75000 {
+		compatible = "qcom,csid530";
+		reg = <0x0 0x5c75000 0x0 0x1000>,
+		      <0x0 0x5c11000 0x0 0x1000>,
+		      <0x0 0x5c13000 0x0 0x4000>;
+		reg-names = "csid", "top", "camnoc";
+		reg-cam-base = <0x75000 0x11000 0x13000>;
+		interrupts = <GIC_SPI 212 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "csid1";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TFE_1_CSID_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_1_CSID_CLK>,
+			 <&gcc GCC_CAMSS_TFE_CPHY_RX_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_1_CPHY_RX_CLK>,
+			 <&gcc GCC_CAMSS_TFE_1_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_1_CLK>;
+		clock-names = "tfe_csid_clk_src",
+			      "tfe_csid_clk",
+			      "cphy_rx_clk_src",
+			      "tfe_cphy_rx_clk",
+			      "tfe_clk_src",
+			      "tfe_clk";
+		clock-rates = <19200000 0 19200000 0 19200000 0>,
+			      <240000000 0 240000000 0 256000000 0>,
+			      <384000000 0 341333333 0 460800000 0>,
+			      <426400000 0 384000000 0 576000000 0>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "turbo";
+		src-clock-name = "tfe_csid_clk_src";
+		operating-points-v2 = <&csid1_opp_table>;
+		clock-control-debugfs = "true";
+		cell-index = <1>;
+		status = "okay";
+
+		csid1_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-240000000 {
+				opp-hz = /bits/ 64 <240000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-384000000 {
+				opp-hz = /bits/ 64 <384000000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-426400000 {
+				opp-hz = /bits/ 64 <426400000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	cam_tfe1: qcom,tfe1@5c75000 {
+		compatible = "qcom,tfe530";
+		reg = <0x0 0x5c75000 0x0 0x5000>;
+		reg-names = "tfe1";
+		reg-cam-base = <0x75000>;
+		interrupts = <GIC_SPI 213 IRQ_TYPE_EDGE_RISING 0>;
+		interrupt-names = "tfe1";
+		power-domains = <&gcc GCC_CAMSS_TOP_GDSC>;
+		clocks = <&gcc GCC_CAMSS_TFE_1_CLK_SRC>,
+			 <&gcc GCC_CAMSS_TFE_1_CLK>;
+		clock-names = "tfe_clk_src",
+			      "tfe_clk";
+		clock-rates = <19200000 0>,
+			      <256000000 0>,
+			      <460800000 0>,
+			      <576000000 0>;
+		clock-cntl-level = "lowsvs", "svs", "svs_l1", "turbo";
+		src-clock-name = "tfe_clk_src";
+		operating-points-v2 = <&vfe1_opp_table>;
+		clock-control-debugfs = "true";
+		cam_hw_pid = <5>;
+		cell-index = <1>;
+		status = "okay";
+
+		vfe1_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-19200000 {
+				opp-hz = /bits/ 64 <19200000>;
+				required-opps = <&rpmpd_opp_low_svs>;
+			};
+
+			opp-256000000 {
+				opp-hz = /bits/ 64 <256000000>;
+				required-opps = <&rpmpd_opp_svs>;
+			};
+
+			opp-460800000 {
+				opp-hz = /bits/ 64 <460800000>;
+				required-opps = <&rpmpd_opp_svs_plus>;
+			};
+
+			opp-576000000 {
+				opp-hz = /bits/ 64 <576000000>;
+				required-opps = <&rpmpd_opp_turbo>;
+			};
+		};
+	};
+
+	qcom,cam-cdm-intf {
+		compatible = "qcom,cam-cdm-intf";
+		label = "cam-cdm-intf";
+		num-hw-cdm = <2>;
+		cdm-client-names = "vfe";
+		cell-index = <0>;
+		status = "okay";
+	};
+
+	qcom,cam-isp {
+		compatible = "qcom,cam-isp";
+		arch-compat = "tfe";
+		status = "okay";
+	};
+
+	qcom,cam-ope {
+		compatible = "qcom,cam-ope";
+		compat-hw-name = "qcom,ope";
+		num-ope = <1>;
+		status = "okay";
+	};
+
+	qcom,cam-req-mgr {
+		compatible = "qcom,cam-req-mgr";
+		status = "okay";
+	};
+
+	qcom,cam-smmu {
+		compatible = "qcom,msm-cam-smmu", "simple-bus";
+		status = "okay";
+
+		msm-cam-smmu-cpas-cdm {
+			compatible = "qcom,msm-cam-smmu-cb";
+			iommus = <&apps_smmu 0x600 0x000>;
+			cam-smmu-label = "cpas-cdm";
+			qcom,iommu-faults = "non-fatal";
+			qcom,iommu-dma-addr-pool = <0x0 0x7400000 0x0 0xd8c00000>;
+			cpas_cdm_iova_mem_map: iova-mem-map {
+				iova-mem-region-io {
+					iova-region-name = "io";
+					iova-region-start = <0x7400000>;
+					iova-region-len = <0xd8c00000>;
+					iova-region-id = <0x3>;
+					status = "okay";
+				};
+			};
+		};
+
+		msm-cam-smmu-ope {
+			compatible = "qcom,msm-cam-smmu-cb";
+			iommus = <&apps_smmu 0x620 0x000>,
+				 <&apps_smmu 0x640 0x000>;
+			qcom,iommu-faults = "non-fatal";
+			multiple-client-devices;
+			qcom,iommu-dma-addr-pool = <0x0 0x7400000 0x0 0xd8c00000>;
+			cam-smmu-label = "ope", "ope-cdm";
+			ope_iova_mem_map: iova-mem-map {
+				iova-mem-region-io {
+					iova-region-name = "io";
+					iova-region-start = <0x7400000>;
+					iova-region-len = <0xd8c00000>;
+					iova-region-id = <0x3>;
+					status = "okay";
+				};
+			};
+		};
+
+		msm-cam-smmu-secure {
+			compatible = "qcom,msm-cam-smmu-cb";
+			cam-smmu-label = "cam-secure";
+			qcom,secure-cb;
+		};
+
+		msm-cam-smmu-tfe {
+			compatible = "qcom,msm-cam-smmu-cb";
+			iommus = <&apps_smmu 0x400 0x000>;
+			qcom,iommu-faults = "non-fatal";
+			qcom,iommu-dma-addr-pool = <0x0 0x7400000 0x0 0xd8c00000>;
+			cam-smmu-label = "tfe";
+			tfe_iova_mem_map: iova-mem-map {
+				iova-mem-region-io {
+					iova-region-name = "io";
+					iova-region-start = <0x7400000>;
+					iova-region-len = <0xd8c00000>;
+					iova-region-id = <0x3>;
+					status = "okay";
+				};
+			};
+		};
+	};
+
+	qcom,cam-sync {
+		compatible = "qcom,cam-sync";
+		status = "okay";
+	};
+
+	qcom,camera {
+		compatible = "qcom,camera_shikra";
+		status = "okay";
+	};
+};
+
+&tlmm {
+	cam_sensor_active_rst0: cam-sensor-active-rst0 {
+		mux {
+			pins = "gpio32";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio32";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_active_rst1: cam-sensor-active-rst1 {
+		mux {
+			pins = "gpio33";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio33";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_mclk0_active: cam-sensor-mclk0-active {
+		mux {
+			pins = "gpio34";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio34";
+			bias-disable;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk0_suspend: cam-sensor-mclk0-suspend {
+		mux {
+			pins = "gpio34";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio34";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk1_active: cam-sensor-mclk1-active {
+		mux {
+			pins = "gpio35";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio35";
+			bias-disable;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk1_suspend: cam-sensor-mclk1-suspend {
+		mux {
+			pins = "gpio35";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio35";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk2_active: cam-sensor-mclk2-active {
+		mux {
+			pins = "gpio96";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio96";
+			bias-disable;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk2_suspend: cam-sensor-mclk2-suspend {
+		mux {
+			pins = "gpio96";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio96";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk3_active: cam-sensor-mclk3-active {
+		mux {
+			pins = "gpio98";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio98";
+			bias-disable;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_mclk3_suspend: cam-sensor-mclk3-suspend {
+		mux {
+			pins = "gpio98";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio98";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cam_sensor_suspend_rst0: cam-sensor-suspend-rst0 {
+		mux {
+			pins = "gpio32";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio32";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_suspend_rst1: cam-sensor-suspend-rst1 {
+		mux {
+			pins = "gpio33";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio33";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cci_i2c_scl0_active: cci-i2c-scl0-active {
+		mux {
+			pins = "gpio37";
+			function = "cci_i2c0";
+		};
+
+		config {
+			pins = "gpio37";
+			bias-pull-up;
+			drive-strength = <2>;
+			qcom,i2c_pull;
+		};
+	};
+
+	cci_i2c_scl0_suspend: cci-i2c-scl0-suspend {
+		mux {
+			pins = "gpio37";
+			function = "cci_i2c0";
+		};
+
+		config {
+			pins = "gpio37";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cci_i2c_scl1_active: cci-i2c-scl1-active {
+		mux {
+			pins = "gpio42";
+			function = "cci_i2c1";
+		};
+
+		config {
+			pins = "gpio42";
+			bias-pull-up;
+			drive-strength = <2>;
+			qcom,i2c_pull;
+		};
+	};
+
+	cci_i2c_scl1_suspend: cci-i2c-scl1-suspend {
+		mux {
+			pins = "gpio42";
+			function = "cci_i2c1";
+		};
+
+		config {
+			pins = "gpio42";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cci_i2c_sda0_active: cci-i2c-sda0-active {
+		mux {
+			pins = "gpio36";
+			function = "cci_i2c0";
+		};
+
+		config {
+			pins = "gpio36";
+			bias-pull-up;
+			drive-strength = <2>;
+			qcom,i2c_pull;
+		};
+	};
+
+	cci_i2c_sda0_suspend: cci-i2c-sda0-suspend {
+		mux {
+			pins = "gpio36";
+			function = "cci_i2c0";
+		};
+
+		config {
+			pins = "gpio36";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+
+	cci_i2c_sda1_active: cci-i2c-sda1-active {
+		mux {
+			pins = "gpio41";
+			function = "cci_i2c1";
+		};
+
+		config {
+			pins = "gpio41";
+			bias-pull-up;
+			drive-strength = <2>;
+			qcom,i2c_pull;
+		};
+	};
+
+	cci_i2c_sda1_suspend: cci-i2c-sda1-suspend {
+		mux {
+			pins = "gpio41";
+			function = "cci_i2c1";
+		};
+
+		config {
+			pins = "gpio41";
+			bias-pull-down;
+			drive-strength = <2>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk-camx.dtso
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/phy/phy.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/clock/qcom,shikra-gcc.h>
+#include <dt-bindings/power/qcom-rpmpd.h>
+#include <dt-bindings/interconnect/qcom,icc.h>
+#include <dt-bindings/interconnect/qcom,shikra.h>
+
+#include "shikra-camera.dtsi"
+
+&cam_csiphy0 {
+	csi-vdd-1p2-supply = <&pm4125_l5>;
+	csi-vdd-1p8-supply = <&pm4125_l13>;
+};
+
+&cam_csiphy1 {
+	csi-vdd-1p2-supply = <&pm4125_l5>;
+	csi-vdd-1p8-supply = <&pm4125_l13>;
+};
+
+&camss {
+	status = "disabled";
+};
+
+&cci {
+	status = "disabled";
+};
+
+&cci_i2c1 {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk-camx.dtso
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/phy/phy.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/clock/qcom,shikra-gcc.h>
+#include <dt-bindings/power/qcom-rpmpd.h>
+#include <dt-bindings/interconnect/qcom,icc.h>
+#include <dt-bindings/interconnect/qcom,shikra.h>
+
+#include "shikra-camera.dtsi"
+
+&cam_csiphy0 {
+	csi-vdd-1p2-supply = <&pm8150_l11>;
+	csi-vdd-1p8-supply = <&pm8150_l12>;
+};
+
+&cam_csiphy1 {
+	csi-vdd-1p2-supply = <&pm8150_l11>;
+	csi-vdd-1p8-supply = <&pm8150_l12>;
+};
+
+&camss {
+	status = "disabled";
+};
+
+&cci {
+	status = "disabled";
+};
+
+&cci_i2c1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add Makefile entries to build and install camera (camx) DTBO overlays for Shikra CQS EVK and IQS EVK board variants.

Each composite DTB bundles the respective base platform DTB with the camx overlay, and registers both the merged .dtb and standalone .dtbo.

CRs-Fixed: 4630873