### PR TITLE
GLYMUR usb fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -5216,6 +5216,7 @@
 			snps,dis_enblslpm_quirk;
 
 			usb-role-switch;
+			wakeup-source;
 
 			status = "disabled";
 
@@ -5291,6 +5292,7 @@
 			snps,dis_enblslpm_quirk;
 
 			usb-role-switch;
+			wakeup-source;
 
 			status = "disabled";
 
@@ -5366,6 +5368,7 @@
 			snps,dis_enblslpm_quirk;
 
 			usb-role-switch;
+			wakeup-source;
 
 			status = "disabled";
 
@@ -5457,6 +5460,7 @@
 
 			qcom,select-utmi-as-pipe-clk;
 			usb-role-switch;
+			wakeup-source;
 
 			status = "disabled";
 		};
@@ -5528,6 +5532,7 @@
 			snps,dis_enblslpm_quirk;
 
 			dr_mode = "host";
+			wakeup-source;
 
 			status = "disabled";
 		};

--- a/arch/arm64/boot/dts/qcom/glymur.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur.dtsi
@@ -5455,6 +5455,9 @@
 
 			maximum-speed = "high-speed";
 
+			qcom,select-utmi-as-pipe-clk;
+			usb-role-switch;
+
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Glymur USB fixes:
1. Addition of wakeup-soruces to all controllers
2. Addition of role switch and utmi fallback property to hs controller