### PR TITLE
arm64: dts: qcom: talos-lyra-evk: Enable PCIe Support

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk-som.dtsi
@@ -31,6 +31,24 @@
 		};
 	};
 
+	vreg_0p9: regulator-0v9 {
+		compatible = "regulator-fixed";
+		regulator-name = "VREG_0P9";
+		regulator-min-microvolt = <900000>;
+		regulator-max-microvolt = <900000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	vreg_1p8: regulator-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VREG_1P8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 };
 
 &apps_rsc {
@@ -206,6 +224,111 @@
 	status = "okay";
 };
 
+&i2c5 {
+	clock-frequency = <100000>;
+
+	status = "okay";
+};
+
+&pcie {
+	wake-gpios = <&tlmm 100 GPIO_ACTIVE_HIGH>;
+
+	iommu-map = <0x0 &apps_smmu 0x400 0x1>,
+		    <0x100 &apps_smmu 0x401 0x1>,
+		    <0x208 &apps_smmu 0x402 0x1>,
+		    <0x210 &apps_smmu 0x403 0x1>,
+		    <0x218 &apps_smmu 0x404 0x1>,
+		    <0x300 &apps_smmu 0x405 0x1>,
+		    <0x400 &apps_smmu 0x406 0x1>,
+		    <0x500 &apps_smmu 0x407 0x1>,
+		    <0x501 &apps_smmu 0x408 0x1>;
+
+	status = "okay";
+};
+
+&pcie_phy {
+	vdda-phy-supply = <&vreg_l5a>;
+	vdda-pll-supply = <&vreg_l12a>;
+
+	status = "okay";
+};
+
+&pcie_port0 {
+	tc9563: pcie@0,0 {
+		compatible = "pci1179,0623";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		#gpio-cells = <2>;
+		device_type = "pci";
+		ranges;
+		bus-range = <0x2 0xff>;
+
+		vddc-supply = <&vreg_0p9>;
+		vdd18-supply = <&vreg_1p8>;
+		vdd09-supply = <&vreg_0p9>;
+		vddio1-supply = <&vreg_1p8>;
+		vddio2-supply = <&vreg_1p8>;
+		vddio18-supply = <&vreg_1p8>;
+
+		i2c-parent = <&i2c5 0x77>;
+
+		resx-gpios = <&tlmm 89 GPIO_ACTIVE_LOW>;
+
+		pinctrl-0 = <&tc9563_resx_state>;
+		pinctrl-names = "default";
+
+		pcie@1,0 {
+			reg = <0x20800 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			device_type = "pci";
+			ranges;
+			bus-range = <0x3 0xff>;
+
+			ep-pwr-en-gpio = <&tc9563 2 GPIO_ACTIVE_HIGH>;
+			ep-reset-gpio = <&tc9563 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		pcie@2,0 {
+			reg = <0x21000 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			device_type = "pci";
+			ranges;
+			bus-range = <0x4 0xff>;
+
+			ep-pwr-en-gpio = <&tc9563 4 GPIO_ACTIVE_HIGH>;
+			ep-reset-gpio = <&tc9563 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		pcie@3,0 {
+			reg = <0x21800 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			device_type = "pci";
+			ranges;
+			bus-range = <0x5 0xff>;
+
+			pci@0,0 {
+				reg = <0x50000 0x0 0x0 0x0 0x0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				device_type = "pci";
+				ranges;
+			};
+
+			pci@0,1 {
+				reg = <0x50100 0x0 0x0 0x0 0x0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				device_type = "pci";
+				ranges;
+			};
+		};
+	};
+};
+
 &remoteproc_adsp {
 	firmware-name = "qcom/qcs615/adsp.mbn";
 
@@ -220,6 +343,31 @@
 
 &rpmhcc {
 	clocks = <&xo_board_clk>;
+};
+
+&tlmm {
+	pcie_default_state: pcie-default-state {
+		clkreq-pins {
+			pins = "gpio90";
+			function = "pcie_clk_req";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+
+		wake-pins {
+			pins = "gpio100";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	tc9563_resx_state: tc9563-resx-state {
+		pins = "gpio89";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
 };
 
 &uart0 {


### PR DESCRIPTION
Enable PCIe support on Talos-Lyra-EVK.

  Brings up the  PCIe root complex and PHY, and the on-board QPS615
  PCIe switch. The switch's upstream port fans out to
  three downstream ports feeding the M.2 Key-B (modem), M.2 Key-M (NVMe),
  and the integrated dual Gigabit Ethernet controllers.