### PR TITLE
BACKPORT: arm64: dts: qcom: rb3gen2: fix BT UART PCIe endpoint

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtso
@@ -96,10 +96,14 @@
 	};
 };
 
-&pcie0_m2_e {
-	port {
-		pcie0_m2_e_ep: endpoint {
-			remote-endpoint = <&m2_e_pcie_ep>;
+&pcie0_port {
+	pcie@0,0 {
+		pcie@2,0 {
+			port {
+				pcie0_m2_e_ep: endpoint {
+					remote-endpoint = <&m2_e_pcie_ep>;
+				};
+			};
 		};
 	};
 };

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -901,7 +901,7 @@
 			bus-range = <0x3 0xff>;
 		};
 
-		pcie0_m2_e: pcie@2,0 {
+		pcie@2,0 {
 			reg = <0x21000 0x0 0x0 0x0 0x0>;
 			#address-cells = <3>;
 			#size-cells = <2>;


### PR DESCRIPTION
The pcie0_m2_e label was added to the base RB3 Gen 2 PCIe1 topology, but the QCC2072 device on the Industrial mezzanine BT UART variant is behind the Industrial PCIe0 switch.

Drop the incorrect base label and patch the actual Industrial PCIe0 downstream port from the BT UART overlay so pwrseq-pcie-m2 can associate the enumerated QCC2072 PCI function with the M.2 connector.

This keeps the downstream QLI branch aligned with the validated nested PCIe endpoint model while the upstream PCIe graph modelling is still being finalized.

CRs-Fixed: 4615698
