### PR TITLE
QCLINUX: Revert Hamoa and Purwa BT always-on workarounds

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
@@ -522,23 +522,6 @@
 		regulator-boot-on;
 	};
 
-	vreg_wcn_bt_en: regulator-wcn-bt-en {
-		compatible = "regulator-fixed";
-
-		regulator-name = "VREG_WCN_BT_EN";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-
-		gpio = <&tlmm 116 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-0 = <&wcn_bt_en>;
-		pinctrl-names = "default";
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
 	vreg_wwan: regulator-wwan {
 		compatible = "regulator-fixed";
 
@@ -704,9 +687,10 @@
 		vddrfa1p2-supply = <&vreg_wcn_1p9>;
 		vddrfa1p8-supply = <&vreg_wcn_1p9>;
 
+		bt-enable-gpios = <&tlmm 116 GPIO_ACTIVE_HIGH>;
 		wlan-enable-gpios = <&tlmm 117 GPIO_ACTIVE_HIGH>;
 
-		pinctrl-0 = <&wcn_wlan_en>;
+		pinctrl-0 = <&wcn_bt_en>, <&wcn_wlan_en>;
 		pinctrl-names = "default";
 
 		regulators {
@@ -1535,13 +1519,13 @@
 		compatible = "qcom,wcn7850-bt";
 		max-speed = <3200000>;
 
-		vddrfacmn-supply = <&vreg_wcn_3p3>;
-		vddaon-supply = <&vreg_wcn_3p3>;
-		vddwlcx-supply = <&vreg_wcn_3p3>;
-		vddwlmx-supply = <&vreg_wcn_3p3>;
-		vddrfa0p8-supply = <&vreg_wcn_3p3>;
-		vddrfa1p2-supply = <&vreg_wcn_3p3>;
-		vddrfa1p8-supply = <&vreg_wcn_3p3>;
+		vddaon-supply = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/purwa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/purwa-iot-evk.dts
@@ -514,23 +514,6 @@
 		regulator-boot-on;
 	};
 
-	vreg_wcn_bt_en: regulator-wcn-bt-en {
-		compatible = "regulator-fixed";
-
-		regulator-name = "VREG_WCN_BT_EN";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-
-		gpio = <&tlmm 116 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-0 = <&wcn_bt_en>;
-		pinctrl-names = "default";
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
 	vreg_wwan: regulator-wwan {
 		compatible = "regulator-fixed";
 
@@ -645,9 +628,10 @@
 		vddrfa1p2-supply = <&vreg_wcn_1p9>;
 		vddrfa1p8-supply = <&vreg_wcn_1p9>;
 
+		bt-enable-gpios = <&tlmm 116 GPIO_ACTIVE_HIGH>;
 		wlan-enable-gpios = <&tlmm 117 GPIO_ACTIVE_HIGH>;
 
-		pinctrl-0 = <&wcn_wlan_en>;
+		pinctrl-0 = <&wcn_bt_en>, <&wcn_wlan_en>;
 		pinctrl-names = "default";
 
 		regulators {
@@ -1520,13 +1504,13 @@
 		compatible = "qcom,wcn7850-bt";
 		max-speed = <3200000>;
 
-		vddaon-supply = <&vreg_wcn_3p3>;
-		vddwlcx-supply = <&vreg_wcn_3p3>;
-		vddwlmx-supply = <&vreg_wcn_3p3>;
-		vddrfacmn-supply = <&vreg_wcn_3p3>;
-		vddrfa0p8-supply = <&vreg_wcn_3p3>;
-		vddrfa1p2-supply = <&vreg_wcn_3p3>;
-		vddrfa1p8-supply = <&vreg_wcn_3p3>;
+		vddaon-supply = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
 	};
 };
 

--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
+++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
@@ -432,20 +432,6 @@ static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
 	    reg_node->parent->parent != ctx->of_node)
 		return PWRSEQ_NO_MATCH;
 
-	/*
-	 * If this is a Bluetooth consumer device but the bt-enable GPIO is not
-	 * configured in the power sequencer (e.g. BT_EN is tied high via a
-	 * hardware pull-up and therefore absent from the DT), don't match.
-	 * The consumer driver will fall back to its legacy power control path
-	 * and correctly set power_ctrl_enabled to false.
-	 *
-	 * BT device nodes are conventionally named "bluetooth" in the DT,
-	 * so use of_node_name_eq() as a generic check rather than enumerating
-	 * specific compatible strings.
-	 */
-	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
-		return PWRSEQ_NO_MATCH;
-
 	return PWRSEQ_MATCH_OK;
 }
 

--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
+++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
@@ -25,7 +25,6 @@ struct pwrseq_qcom_wcn_pdata {
 	unsigned int gpio_enable_delay_ms;
 	const struct pwrseq_target_data **targets;
 	bool has_vddio; /* separate VDD IO regulator */
-	bool bt_gpio_required; /* BT enable path requires a dedicated GPIO */
 	int (*match)(struct pwrseq_device *pwrseq, struct device *dev);
 };
 
@@ -384,7 +383,6 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn6855_of_data = {
 	.pwup_delay_ms = 50,
 	.gpio_enable_delay_ms = 5,
 	.targets = pwrseq_qcom_wcn6855_targets,
-	.bt_gpio_required = true,
 };
 
 static const char *const pwrseq_wcn7850_vregs[] = {
@@ -402,7 +400,6 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn7850_of_data = {
 	.num_vregs = ARRAY_SIZE(pwrseq_wcn7850_vregs),
 	.pwup_delay_ms = 50,
 	.targets = pwrseq_qcom_wcn_targets,
-	.bt_gpio_required = true,
 };
 
 static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
@@ -442,17 +439,11 @@ static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
 	 * The consumer driver will fall back to its legacy power control path
 	 * and correctly set power_ctrl_enabled to false.
 	 *
-	 * Only apply this check for chips whose BT enable path requires a
-	 * dedicated GPIO (bt_gpio_required).  Chips like WCN3990 have no
-	 * separate BT/WLAN enable pins by design and must always be matched
-	 * even when bt_gpio is NULL.
-	 *
 	 * BT device nodes are conventionally named "bluetooth" in the DT,
 	 * so use of_node_name_eq() as a generic check rather than enumerating
 	 * specific compatible strings.
 	 */
-	if (ctx->pdata->bt_gpio_required && !ctx->bt_gpio &&
-	    of_node_name_eq(dev_node, "bluetooth"))
+	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
 		return PWRSEQ_NO_MATCH;
 
 	return PWRSEQ_MATCH_OK;


### PR DESCRIPTION
Revert the temporary BT-related workarounds superseded by the proper M.2 Key E connector DT solution (pwrseq-pcie-m2).

**Commits:**
1. `QCLINUX: Revert "WORKAROUND: arm64: dts: qcom: hamoa-iot-evk: support Bluetooth over both USB and UART"` — reverts f2ee87014e91
2. `QCLINUX: Revert "WORKAROUND: arm64: dts: qcom: purwa-iot-evk: support Bluetooth over both USB and UART"` — reverts 3aff69522614
3. `QCLINUX: Revert "WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO" (06f2b9c60834)` — reverts 06f2b9c60834 (bt_gpio_required flag refinement)
4. `QCLINUX: Revert "WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO" (5a472e184be9)` — reverts 5a472e184be9 (base skip logic)

**Board-level WAs (1, 2):** modeled BT_EN (GPIO116) as always-on fixed regulators to prevent hci_qca UART driver interference when BT operates over USB. No longer needed — the M.2 solution uses pwrseq-pcie-m2 to control W_DISABLE2# (GPIO116) based on PCIe device enumeration.

**Driver-level WAs (3, 4):** made pwrseq-qcom-wcn skip matching "bluetooth" DT nodes when bt-enable GPIO is absent. No longer needed — the M.2 solution routes BT power sequencing through pwrseq-pcie-m2, so pwrseq-qcom-wcn no longer needs to skip these nodes.

M.2 solution PRs:
- https://github.com/qualcomm-linux/kernel-topics/pull/1629
- https://github.com/qualcomm-linux/kernel-topics/pull/1628

CRs-Fixed: 4630764
