### PR TITLE
FROMLIST: arm64: dts: qcom: glymur: Add ADC support for Glymur CRD

### DIFF
--- a/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
+++ b/arch/arm64/boot/dts/qcom/glymur-crd.dtsi
@@ -12,6 +12,7 @@
 
 #include <dt-bindings/input/gpio-keys.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include "qcom-adc5-gen4.h"
 
 / {
 	model = "Qualcomm Technologies, Inc. Glymur CRD";
@@ -210,6 +211,26 @@
 		pinctrl-names = "default";
 
 		regulator-boot-on;
+	};
+
+	thermal-zones {
+		sys-0-thermal {
+			thermal-sensors = <&pmk8850_vadc ADC5_GEN4_AMUX1_THM_100K_PU(0, 0)>;
+
+			trips {
+				trip0 {
+					temperature = <70000>;
+					hysteresis = <2000>;
+					type = "hot";
+				};
+
+				trip1 {
+					temperature = <90000>;
+					hysteresis = <2000>;
+					type = "hot";
+				};
+			};
+		};
 	};
 
 	vreg_nvme: regulator-nvme {
@@ -963,12 +984,37 @@
 	wake-gpios = <&tlmm 151 GPIO_ACTIVE_LOW>;
 };
 
+&pmcx0102_c_e0_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(0, 2)>;
+	io-channel-names = "thermal";
+};
+
+&pmcx0102_c_e1_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(1, 2)>;
+	io-channel-names = "thermal";
+};
+
+&pmcx0102_d_e0_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(0, 3)>;
+	io-channel-names = "thermal";
+};
+
+&pmcx0102_d_e1_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(1, 3)>;
+	io-channel-names = "thermal";
+};
+
 &pmh0101_gpios {
 	nvme_reg_en: nvme-reg-en-state {
 		pins = "gpio14";
 		function = "normal";
 		bias-disable;
 	};
+};
+
+&pmh0101_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(0, 1)>;
+	io-channel-names = "thermal";
 };
 
 &pmh0110_f_e1_gpios {
@@ -1001,8 +1047,105 @@
 	};
 };
 
+&pmh0110_f_e0_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(0, 5)>;
+	io-channel-names = "thermal";
+};
+
+&pmh0110_f_e1_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(1, 5)>;
+	io-channel-names = "thermal";
+};
+
+&pmh0110_h_e0_temp_alarm {
+	io-channels = <&pmk8850_vadc ADC5_GEN4_DIE_TEMP(0, 7)>;
+	io-channel-names = "thermal";
+};
+
 &pmk8850_rtc {
 	qcom,no-alarm;
+};
+
+&pmk8850_vadc {
+	channel@103 {
+		reg = <ADC5_GEN4_DIE_TEMP(0, 1)>;
+		label = "pmh0101_die_temp";
+	};
+
+	channel@18e {
+		reg = <ADC5_GEN4_VPH_PWR(0, 1)>;
+		label = "pmh0101_vph_pwr";
+	};
+
+	channel@203 {
+		reg = <ADC5_GEN4_DIE_TEMP(0, 2)>;
+		label = "pmcx0102_c_e0_die_temp";
+	};
+
+	channel@28e {
+		reg = <ADC5_GEN4_VPH_PWR(0, 2)>;
+		label = "pmcx0102_c_e0_vph_pwr";
+	};
+
+	channel@303 {
+		reg = <ADC5_GEN4_DIE_TEMP(0, 3)>;
+		label = "pmcx0102_d_e0_die_temp";
+	};
+
+	channel@38e {
+		reg = <ADC5_GEN4_VPH_PWR(0, 3)>;
+		label = "pmcx0102_d_e0_vph_pwr";
+	};
+
+	channel@503 {
+		reg = <ADC5_GEN4_DIE_TEMP(0, 5)>;
+		label = "pmh0110_f_e0_die_temp";
+	};
+
+	channel@58e {
+		reg = <ADC5_GEN4_VPH_PWR(0, 5)>;
+		label = "pmh0110_f_e0_vph_pwr";
+	};
+
+	channel@703 {
+		reg = <ADC5_GEN4_DIE_TEMP(0, 7)>;
+		label = "pmh0110_h_e0_die_temp";
+	};
+
+	channel@78e {
+		reg = <ADC5_GEN4_VPH_PWR(0, 7)>;
+		label = "pmh0110_h_e0_vph_pwr";
+	};
+
+	channel@2203 {
+		reg = <ADC5_GEN4_DIE_TEMP(1, 2)>;
+		label = "pmcx0102_c_e1_die_temp";
+	};
+
+	channel@228e {
+		reg = <ADC5_GEN4_VPH_PWR(1, 2)>;
+		label = "pmcx0102_c_e1_vph_pwr";
+	};
+
+	channel@2303 {
+		reg = <ADC5_GEN4_DIE_TEMP(1, 3)>;
+		label = "pmcx0102_d_e1_die_temp";
+	};
+
+	channel@238e {
+		reg = <ADC5_GEN4_VPH_PWR(1, 3)>;
+		label = "pmcx0102_d_e1_vph_pwr";
+	};
+
+	channel@2503 {
+		reg = <ADC5_GEN4_DIE_TEMP(1, 5)>;
+		label = "pmh0110_f_e1_die_temp";
+	};
+
+	channel@258e {
+		reg = <ADC5_GEN4_VPH_PWR(1, 5)>;
+		label = "pmh0110_f_e1_vph_pwr";
+	};
 };
 
 &pon_resin {


### PR DESCRIPTION
Add the ADC channels under the PMK8850 ADC node for the other PMICS on the board with ADC peripherals. This includes die temperature and VPH power channels per PMIC.

Add a thermal zone corresponding to the PMK8850 xo_therm ADC thermistor channel to enable temperature monitoring.

Also add io-channels and io-channel-names properties to the temp_alarm nodes so that they can get temperature reading from the newly added ADC die_temp channels.

Link: https://lore.kernel.org/all/20260731-pmic5_gen4_adc-v1-6-9c49b2eea6f9@oss.qualcomm.com/

CRs-fixed: 4579801
Depends-on: https://github.com/qualcomm-linux/kernel-topics/pull/1632