### PR TITLE
FROMLIST: arm64: dts: qcom: sc7280: Add dma-coherent property

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak.dtsi
+++ b/arch/arm64/boot/dts/qcom/kodiak.dtsi
@@ -5033,6 +5033,8 @@
 					<&mmss_noc MASTER_VIDEO_P0 0 &mc_virt SLAVE_EBI1 0>;
 			interconnect-names = "cpu-cfg", "video-mem";
 
+			dma-coherent;
+
 			iommus = <&apps_smmu 0x2180 0x20>;
 			memory-region = <&video_mem>;
 


### PR DESCRIPTION
DMA coherency fix for sc7280 venus node (dts ): The venus DT node was missing dma-coherent, so DMA buffers shared between the CPU and the venus hardware were not guaranteed I/O coherent. This caused hardware faults with high-resolution clips and data corruption in captured output. Adds dma-coherent to the binding and to the sc7280 venus node.

Depends-On :https://github.com/qualcomm-linux/kernel-topics/pull/1640
CRs-fixed: 4446385