### PR TITLE
QCLINUX: memory-dump: add memory dump table for Glymur

### DIFF
--- a/drivers/firmware/qcom/memory_dump_dev.c
+++ b/drivers/firmware/qcom/memory_dump_dev.c
@@ -435,6 +435,13 @@ static const struct dump_table shikra_dump_table = {
 	.imem_size	= 0x8,
 };
 
+static const struct dump_table glymur_dump_table = {
+	.items		= hamoa_items,
+	.num_of_items	= ARRAY_SIZE(hamoa_items),
+	.imem_base	= 0x14680010,
+	.imem_size	= 0x8,
+};
+
 static int __init mem_dump_dev_init(void)
 {
 	int ret;
@@ -512,12 +519,6 @@ static int __init mem_dump_dev_init(void)
 	case 616:
 	case 709:
 	case 710:
-	/* Glymur chip IDs */
-	case 662:
-	case 698:
-	case 699:
-	case 718:
-	case 719:
 		ret = platform_device_add_data(mem_dump_pdev,
 				&hamoa_dump_table, sizeof(hamoa_dump_table));
 		if (ret)
@@ -529,6 +530,16 @@ static int __init mem_dump_dev_init(void)
 	case 759:
 		ret = platform_device_add_data(mem_dump_pdev,
 				&shikra_dump_table, sizeof(shikra_dump_table));
+		if (ret)
+			goto fail;
+		break;
+	case 662:
+	case 698:
+	case 699:
+	case 718:
+	case 719:
+		ret = platform_device_add_data(mem_dump_pdev,
+				&glymur_dump_table, sizeof(glymur_dump_table));
 		if (ret)
 			goto fail;
 		break;


### PR DESCRIPTION
Glymur was reusing Hamoa's dump table, but its IMEM base address differs. Add a dedicated dump table for Glymur with the correct imem_base and register it under Glymur's chip IDs.