### PR TITLE
QCLINUX: qcom.config: Enable FUNCTION_TRACER

### DIFF
--- a/arch/arm64/configs/qcom.config
+++ b/arch/arm64/configs/qcom.config
@@ -133,6 +133,7 @@ CONFIG_SCSI_SMARTPQI=m
 
 # Support performance profiling
 CONFIG_FTRACE=y
+CONFIG_FUNCTION_TRACER=y
 
 # QCOM SCMI memlat bus scaling
 CONFIG_QCOM_SCMI_GENERIC_EXT=y


### PR DESCRIPTION
CONFIG_FUNCTION_TRACER is useful for custom schedulers, so enable it in default build.

CRs-Fixed: 4639432