### PR TITLE
arm64: dts: qcom: hamoa: Fix pcie4_port0_ep endpoint stub location

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -3733,11 +3733,6 @@
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
-
-				port {
-					pcie4_port0_ep: endpoint {
-					};
-				};
 			};
 		};
 
@@ -3878,6 +3873,11 @@
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
+
+				port {
+					pcie4_port0_ep: endpoint {
+					};
+				};
 			};
 		};
 


### PR DESCRIPTION
The pcie4_port0_ep endpoint stub was incorrectly added inside the
pcie5_port0 child node due to a context-matching error during patch
application. Move it to the correct pcie4_port0 child node.

Only hamoa.dtsi changes (5 insertions, 5 deletions — moving the stub
from pcie5_port0 to pcie4_port0).

Fixes: 2d5178812b14 ("FROMLIST: arm64: dts: qcom: hamoa: Add graph port/endpoint anchors to pcie4_port0 and uart14")

CRs-Fixed: 4630764