### PR TITLE
QCLINUX: arm64: dts: qcom: Add flag to enable aggregated CSIPHY

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa-camera.dtsi
@@ -1636,6 +1636,7 @@
 		src-clock-name = "csi0phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy0_opp_table>;
 		cell-index = <0>;
 		status = "okay";
@@ -1678,6 +1679,7 @@
 		src-clock-name = "csi1phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy1_opp_table>;
 		cell-index = <1>;
 		status = "okay";
@@ -1720,6 +1722,7 @@
 		src-clock-name = "csi2phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy2_opp_table>;
 		cell-index = <2>;
 		status = "okay";
@@ -1762,6 +1765,7 @@
 		src-clock-name = "csi4phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy4_opp_table>;
 		cell-index = <4>;
 		status = "okay";

--- a/arch/arm64/boot/dts/qcom/purwa-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/purwa-camera.dtsi
@@ -1333,6 +1333,7 @@
 		src-clock-name = "csi0phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy0_opp_table>;
 		cell-index = <0>;
 		status = "okay";
@@ -1375,6 +1376,7 @@
 		src-clock-name = "csi4phytimer_clk_src";
 		clock-cntl-level = "nominal";
 		clock-rates = <480000000 0 400000000 0>;
+		aggregator-rx;
 		operating-points-v2 = <&csiphy4_opp_table>;
 		cell-index = <4>;
 		status = "okay";


### PR DESCRIPTION
Add flag "aggregator-rx" to the Hamoa and Purwa camera dtsi.

This change enables the aggregated CSIPHY to enable the GMSL Camera and Per-port feature.

CRs-Fixed: 4655734
