### PR TITLE
arm64: dts: qcom: talos-lyra-evk: Enable TPM (ST33)

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
@@ -22,3 +22,13 @@
 
 	status = "okay";
 };
+
+&spi6 {
+        status = "okay";
+
+        tpm@0 {
+                compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+                reg = <0>;
+                spi-max-frequency = <20000000>;
+        };
+};


### PR DESCRIPTION
Enable dTPM (ST33HTPH2X32AHE4) support over SPI6 on the Talos Lyra EVK by adding the required SPI and TPM nodes.

CRs-Fixed: 4645655