### PR TITLE
FROMLIST: coresight: fix trace ID search skipping pass-through NoC devices

### DIFF
--- a/drivers/hwtracing/coresight/coresight-core.c
+++ b/drivers/hwtracing/coresight/coresight-core.c
@@ -980,8 +980,12 @@ int coresight_path_assign_trace_id(struct coresight_path *path,
 		/* Assign a trace ID to the path for the first device that wants to do it */
 		trace_id = coresight_get_trace_id(nd->csdev, mode, sink);
 
-		/* 0 means the device has no ID assignment, so keep searching */
-		if (trace_id == 0)
+		/*
+		 * 0 means the device has no ID assignment, and -EOPNOTSUPP
+		 * means the device explicitly declines to assign one (e.g. a
+		 * pass-through NoC) - in both cases keep searching downstream.
+		 */
+		if (trace_id == 0 || trace_id == -EOPNOTSUPP)
 			continue;
 
 		if (!IS_VALID_CS_TRACE_ID(trace_id))


### PR DESCRIPTION
coresight_path_assign_trace_id() only treats a trace_id of 0 as "this device has no ID assignment, keep searching downstream". Pass-through NoC links such as itnoc (qcom,coresight-itnoc) intentionally return -EOPNOTSUPP from their .trace_id callback since they have no ATID register to program, but that negative value falls through to the IS_VALID_CS_TRACE_ID() check and is rejected, aborting the whole path with -EINVAL before the real trace ID owner further downstream is ever reached.

This breaks enabling any source whose path traverses an itnoc, e.g. writing 1 to tpdm/enable_source for a TPDM fails with:

  sh: write error: Invalid argument

Skip devices that return -EOPNOTSUPP the same way as devices that return 0, so the search continues to the next device on the path.

Link: https://lore.kernel.org/all/20260817-fix-trace-id-assign-issue-v1-1-b2164e33f9fa@oss.qualcomm.com/
Fixes: f4526ffee6ff ("coresight: fix missing error code when trace ID is invalid")