### PR TITLE
arm64: dts: qcom: monaco: Move graph port/endpoint anchors to board file

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -80,8 +80,12 @@
 	};
 };
 
-&pcieport0_ep {
-	remote-endpoint = <&m2_e_pcie_ep>;
+&pcieport0 {
+	port {
+		pcieport0_ep: endpoint {
+			remote-endpoint = <&m2_e_pcie_ep>;
+		};
+	};
 };
 
 &sdhc_1 {
@@ -97,8 +101,10 @@
 
 &uart2 {
 	status = "okay";
-};
 
-&uart2_ep {
-	remote-endpoint = <&m2_e_uart_ep>;
+	port {
+		uart2_ep: endpoint {
+			remote-endpoint = <&m2_e_uart_ep>;
+		};
+	};
 };

--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -1262,10 +1262,6 @@
 				power-domains = <&rpmhpd RPMHPD_CX>;
 				operating-points-v2 = <&qup_opp_table>;
 				status = "disabled";
-
-				port {
-					uart2_ep: endpoint {};
-				};
 			};
 
 			i2c3: i2c@98c000 {
@@ -2484,10 +2480,6 @@
 				#size-cells = <2>;
 				ranges;
 				phys = <&pcie0_phy>;
-
-				port {
-					pcieport0_ep: endpoint {};
-				};
 			};
 		};
 


### PR DESCRIPTION
  Fix a BT initialization regression on qcs8300-ride introduced by commit 2479c6b2096e.

  Move the port/endpoint nodes from monaco.dtsi into monaco-evk.dts
  where the M.2 Key E connector is actually described. This ensures
  of_graph_is_present() only returns true on boards with a real M.2
  connection.

  Fixes: 2479c6b2096e ("FROMLIST: arm64: dts: qcom: monaco: Add graph port/endpoint anchors to pcieport0 and uart2")
  CRs-Fixed: 4610036