### PR TITLE
Revert "FROMLIST: arm64: dts: qcom: monaco: enable audio ML offload memory and SMMU mappings"

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-el2.dtso
@@ -20,9 +20,7 @@
 };
 
 &remoteproc_adsp {
-	iommus = <&apps_smmu 0x2000 0x0>,
-		<&apps_smmu 0x2060 0x9>,
-		<&apps_smmu 0x2062 0x1>;
+	iommus = <&apps_smmu 0x2000 0x0>;
 };
 
 &remoteproc_cdsp {

--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -795,14 +795,6 @@
 		#size-cells = <2>;
 		ranges;
 
-		audio_cma_mem: qcom,audio-ml {
-			compatible = "shared-dma-pool";
-			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
-			reusable;
-			alignment = <0x0 0x400000>;
-			size = <0x0 0x1000000>;
-		};
-
 		aop_image_mem: aop-image-region@90800000 {
 			reg = <0x0 0x90800000 0x0 0x60000>;
 			no-map;
@@ -2929,7 +2921,6 @@
 						q6apmdai: dais {
 							compatible = "qcom,q6apm-dais";
 							iommus = <&apps_smmu 0x2001 0x0>;
-							memory-region = <&audio_cma_mem>;
 						};
 					};
 


### PR DESCRIPTION
This reverts commit cd0f5c65c4d5fe21873336b4fe32536b88b12ded.