### PR TITLE
FROMLIST: drm/msm/dpu: advertise linear-only modifiers on platforms w…

### DIFF
--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_plane.c
+++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_plane.c
@@ -94,6 +94,11 @@ static const uint64_t supported_format_modifiers[] = {
 	DRM_FORMAT_MOD_INVALID
 };
 
+static const uint64_t supported_format_modifiers_no_ubwc[] = {
+	DRM_FORMAT_MOD_LINEAR,
+	DRM_FORMAT_MOD_INVALID
+};
+
 #define to_dpu_plane(x) container_of(x, struct dpu_plane, base)
 
 static struct dpu_kms *_dpu_plane_get_kms(struct drm_plane *plane)
@@ -1836,7 +1841,10 @@ static struct drm_plane *dpu_plane_init_common(struct drm_device *dev,
 	pdpu = drmm_universal_plane_alloc(dev, struct dpu_plane, base,
 				0xff, &dpu_plane_funcs,
 				format_list, num_formats,
-				supported_format_modifiers, type, NULL);
+				(kms->mdss->ubwc_enc_version == 0) ?
+					supported_format_modifiers_no_ubwc :
+					supported_format_modifiers,
+				type, NULL);
 	if (IS_ERR(pdpu))
 		return ERR_CAST(pdpu);
 


### PR DESCRIPTION
Certain Qualcomm targets like QCM2290 and Shikra do not have UBWC support. On such targets, advertising DRM_FORMAT_MOD_QCOM_COMPRESSED in the supported modifier list causes userspace to attempt UBWC allocations that the kernel rejects:

  msm_dpu: [drm] *ERROR* unsupported format modifier 500000000000003
  msm_dpu: [drm] *ERROR* unsupported pixel format: AR24 little-endian

On platforms without UBWC, only advertise DRM_FORMAT_MOD_LINEAR to avoid exposing formats that the hardware cannot handle.

Fixes: 71c5c23be874 ("drm/msm/dpu: check ubwc support before adding compressed formats")
Link: https://lore.kernel.org/r/20260819-remove_ubwc-v1-1-5357d5cc517f@oss.qualcomm.com

CRs-fixed: 4648534