### PR TITLE
arm64: dts: qcom: talos-lyra-evk: Enable Native DP

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
@@ -11,6 +11,33 @@
 	compatible = "qcom,talos-lyra-evk", "qcom,talos-lyra-evk-som", "qcom,qcs615",
 		     "qcom,sm6150";
 	chassis-type = "embedded";
+
+	dp0-connector {
+		compatible = "dp-connector";
+		label = "DP0";
+		type = "full-size";
+
+		hpd-gpios = <&tlmm 104 GPIO_ACTIVE_HIGH>;
+
+		port {
+			dp0_connector_in: endpoint {
+				remote-endpoint = <&mdss_dp0_out>;
+			};
+		};
+	};
+};
+
+&mdss {
+        status = "okay";
+};
+
+&mdss_dp0 {
+        status = "okay";
+};
+
+&mdss_dp0_out {
+        link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000>;
+        remote-endpoint = <&dp0_connector_in>;
 };
 
 &pon_pwrkey {


### PR DESCRIPTION
Enabled Native DP with DP-connector using tlmm hpd-gpio 104.