### PR TITLE
FROMGIT: power: supply: qcom_battmgr: fix battery chemistry strncmp …

### DIFF
--- a/drivers/power/supply/qcom_battmgr.c
+++ b/drivers/power/supply/qcom_battmgr.c
@@ -1237,11 +1237,11 @@ static void qcom_battmgr_sc8280xp_strcpy(char *dest, const char *src)
 
 static unsigned int qcom_battmgr_sc8280xp_parse_technology(const char *chemistry)
 {
-	if ((!strncmp(chemistry, "LIO", BATTMGR_CHEMISTRY_LEN)) ||
-	    (!strncmp(chemistry, "OOI", BATTMGR_CHEMISTRY_LEN)))
+	if ((!strncmp(chemistry, "LIO", 3)) ||
+	    (!strncmp(chemistry, "OOI", 3)))
 		return POWER_SUPPLY_TECHNOLOGY_LION;
-	if (!strncmp(chemistry, "LIP", BATTMGR_CHEMISTRY_LEN) ||
-	    !strncmp(chemistry, "LiP", BATTMGR_CHEMISTRY_LEN))
+	if (!strncmp(chemistry, "LIP", 3) ||
+	    !strncmp(chemistry, "LiP", 3))
 		return POWER_SUPPLY_TECHNOLOGY_LIPO;
 
 	pr_err("Unknown battery technology '%s'\n", chemistry);


### PR DESCRIPTION
FROMGIT: power: supply: qcom_battmgr: fix battery chemistry strncmp

The battery_chemistry field is a 4-byte array without guaranteed null termination. Using BATTMGR_CHEMISTRY_LEN (4) as the strncmp length for 3-character string literals implicitly requires chemistry[3] == '\0', which may not hold. Use 3 instead to match only the significant bytes.

Link: https://lore.kernel.org/all/20260812-fix-qcom-batt-chemistry-strn-v1-1-458545e02641@oss.qualcomm.com/

CRs-Fixed: 4562260