### PR TITLE
FROMLIST: arm64: dts: qcom: shikra: Enable dTPM on EVK boards

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -196,6 +196,16 @@
 	};
 };
 
+&spi5 {
+        status = "okay";
+
+        tpm@0 {
+                compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+                reg = <0>;
+                spi-max-frequency = <20000000>;
+        };
+};
+
 &usb_1_hsphy {
 	vdd-supply = <&pm4125_l12>;
 	vdda-pll-supply = <&pm4125_l13>;

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -192,6 +192,16 @@
 	};
 };
 
+&spi5 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &usb_1_hsphy {
 	vdd-supply = <&pm4125_l12>;
 	vdda-pll-supply = <&pm4125_l13>;

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -191,6 +191,16 @@
 	};
 };
 
+&spi5 {
+        status = "okay";
+
+        tpm@0 {
+                compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+                reg = <0>;
+                spi-max-frequency = <20000000>;
+        };
+};
+
 &usb_1_hsphy {
 	vdd-supply = <&pm8150_l4>;
 	vdda-pll-supply = <&pm8150_l12>;


### PR DESCRIPTION
The Shikra EVK boards (CQM, CQS, IQS) carry an ST33 discrete TPM connected via SPI5. Enable the SPI controller and add the TPM node with the ST33HTPM compatible and a 20 MHz max clock.

Depends-on: https://lore.kernel.org/all/20260820085347.822-1-xueyao.an@oss.qualcomm.com/


Link: https://lore.kernel.org/all/20260820-shikra_dtpm-v1-1-40d96b8238bb@oss.qualcomm.com/


CRs-Fixed: 4654974