### PR TITLE
FROMLIST: arm64: dts: qcom: shikra: Fix gpio-reserved-ranges to allow…

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-som.dtsi
@@ -317,7 +317,6 @@
 
 &tlmm {
 	gpio-reserved-ranges = <6 4>, /* Fingerprint SPI */
-			       <14 4>, /* eSE SPI */
 			       <30 2>, /* NFC SPI */
 			       <138 1>, /* NFC Secure IO */
 			       <155 11>; /* eMMC Boot */

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-som.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-som.dtsi
@@ -332,7 +332,6 @@
 
 &tlmm {
 	 gpio-reserved-ranges = <6 4>, /* Fingerprint SPI */
-			       <14 4>, /* eSE SPI */
 			       <30 2>, /* NFC SPI */
 			       <138 1>, /* NFC Secure IO */
 			       <155 11>; /* eMMC Boot */


### PR DESCRIPTION
… SPI5 access

GPIOs 14-17 are routed to the SPI5 bus on the Shikra EVK boards. These pins were incorrectly included in the tlmm gpio-reserved-ranges, preventing Linux from claiming the SPI5 controller. SPI5 is needed to support the ST33 discrete TPM connected to the EVK boards.

Since there is no TZ use case for these pins, remove them from the reserved list in shikra-cqm-som.dtsi and shikra-iqs-som.dtsi. The CQS variant inherits this change via its include of one of these files.

Fixes: 234030fb4824 ("arm64: dts: qcom: shikra: Add gpio-reserved-ranges to tlmm")


Link: https://lore.kernel.org/all/20260820085347.822-1-xueyao.an@oss.qualcomm.com/

CRs-Fixed: 4655096