### PR TITLE
Revert "WORKAROUND: Revert "drm/msm/dpu: enable virtual planes

### DIFF
--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_kms.c
+++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_kms.c
@@ -52,7 +52,7 @@
 #define DPU_DEBUGFS_DIR "msm_dpu"
 #define DPU_DEBUGFS_HWMASKNAME "hw_log_mask"
 
-bool dpu_use_virtual_planes;
+bool dpu_use_virtual_planes = true;
 module_param(dpu_use_virtual_planes, bool, 0);
 
 static int dpu_kms_hw_init(struct msm_kms *kms);


### PR DESCRIPTION
…ault""

The kaanapali-MTP crash that prompted the workaround was due to frame done timeouts on DSI. That issue is now fixed and frame done timeouts are no longer seen on kaanapali DSI with virtual planes enabled.

Virtual planes are also required for 4K display support on Kodiak (SC7280).

Re-enable virtual planes by default.

This reverts commit 7a17c61afed818b236a155c3ea77afb994cf37ca.

CRs-Fixed: 4656634