### PR TITLE
 Talos Lyra DSI Display panels Addition

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -414,6 +414,8 @@ talos-lyra-evk-camx-dtbs	:= talos-lyra-evk.dtb talos-lyra-evk-camx.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk-camx.dtb
 talos-lyra-evk-dlc0697-dtbs	:= talos-lyra-evk.dtb talos-lyra-evk-dlc0697.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk-dlc0697.dtb
+talos-lyra-evk-raspberrypi-dsi-7inch-dtbs	:= talos-lyra-evk.dtb talos-lyra-evk-raspberrypi-dsi-7inch.dtbo
+dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk-raspberrypi-dsi-7inch.dtb
 
 x1e001de-devkit-el2-dtbs	:= x1e001de-devkit.dtb x1-el2.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= x1e001de-devkit.dtb x1e001de-devkit-el2.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -412,6 +412,9 @@ dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-lvds-auo,g133han01.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk.dtb
 talos-lyra-evk-camx-dtbs	:= talos-lyra-evk.dtb talos-lyra-evk-camx.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk-camx.dtb
+talos-lyra-evk-dlc0697-dtbs	:= talos-lyra-evk.dtb talos-lyra-evk-dlc0697.dtbo
+dtb-$(CONFIG_ARCH_QCOM)	+= talos-lyra-evk-dlc0697.dtb
+
 x1e001de-devkit-el2-dtbs	:= x1e001de-devkit.dtb x1-el2.dtbo
 dtb-$(CONFIG_ARCH_QCOM)	+= x1e001de-devkit.dtb x1e001de-devkit-el2.dtb
 x1e78100-lenovo-thinkpad-t14s-el2-dtbs	:= x1e78100-lenovo-thinkpad-t14s.dtb x1-el2.dtbo

--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk-dlc0697.dtso
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk-dlc0697.dtso
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&lt9611uxd {
+	status = "disabled";
+	/delete-node/ ports;
+};
+
+&hdmi_connector {
+	status = "disabled";
+};
+
+&mdss_dsi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	panel@0 {
+		compatible = "dlc,dlc0697";
+		reg = <0>;
+
+		reset-gpios = <&tlmm 118 GPIO_ACTIVE_LOW>;
+		enable-gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
+
+		vddio-supply = <&vreg_s4a>;
+		bias-supply = <&vreg_disp_3p3>;
+
+		pinctrl-0 = <&panel_rst_n &panel_te_pin &backlight_en>;
+		pinctrl-1 = <&panel_rst_n_suspend>;
+		pinctrl-names = "default", "sleep";
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	remote-endpoint = <&panel_in>;
+	data-lanes = <0 1 2 3>;
+};
+
+&tlmm {
+	backlight_en: backlight-en-state {
+		pins = "gpio2";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	panel_rst_n: panel-rst-n-state {
+		pins = "gpio118";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	panel_rst_n_suspend: panel-rst-n-suspend-state {
+		pins = "gpio118";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	panel_te_pin: panel-te-pin-state {
+		pins = "gpio98";
+		function = "mdp_vsync";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk-raspberrypi-dsi-7inch.dtso
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk-raspberrypi-dsi-7inch.dtso
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&{/} {
+	display_bl: backlight {
+		compatible = "pwm-backlight";
+		power-supply = <&vreg_disp_3p3>;
+		pwms = <&reg_backlight 0 255 0>;
+	};
+};
+
+&lt9611uxd {
+	status = "disabled";
+};
+
+&hdmi_connector {
+	status = "disabled";
+};
+
+/*
+ * Override vreg_disp_3p3: switch GPIO from tlmm 3 (lt9611) to expander0 pin 1
+ * (RPI panel/touch 3.3V supply).
+ */
+&vreg_disp_3p3 {
+	regulator-name = "rpi-dsi-touch";
+	gpio = <&expander0 1 GPIO_ACTIVE_HIGH>;
+	/delete-property/ pinctrl-0;
+	/delete-property/ pinctrl-names;
+	regulator-boot-on;
+	regulator-always-on;
+};
+
+&i2c2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	reg_backlight: reg_backlight@45 {
+		compatible = "raspberrypi,touchscreen-panel-regulator-v2";
+		reg = <0x45>;
+		vcc-supply = <&vreg_disp_3p3>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#pwm-cells = <3>;
+	};
+};
+
+&mdss_dsi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	panel@0 {
+		compatible = "raspberrypi,dsi-7inch";
+		reg = <0>;
+
+		reset-gpios = <&reg_backlight 0 GPIO_ACTIVE_LOW>;
+		power-supply = <&vreg_disp_3p3>;
+		iovcc-supply = <&vreg_s4a>;
+		backlight = <&display_bl>;
+
+		port {
+			panel0_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	remote-endpoint = <&panel0_in>;
+	data-lanes = <0 1>;
+};

--- a/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
+++ b/arch/arm64/boot/dts/qcom/talos-lyra-evk.dts
@@ -4,6 +4,7 @@
  */
 /dts-v1/;
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 #include "talos-lyra-evk-som.dtsi"
 
@@ -12,6 +13,10 @@
 	compatible = "qcom,talos-lyra-evk", "qcom,talos-lyra-evk-som", "qcom,qcs615",
 		     "qcom,sm6150";
 	chassis-type = "embedded";
+
+	aliases {
+		i2c2 = &i2c2;
+	};
 
 	dp0-connector {
 		compatible = "dp-connector";
@@ -27,7 +32,7 @@
 		};
 	};
 
-	hdmi-connector {
+	hdmi_connector: hdmi-connector {
 		compatible = "hdmi-connector";
 		type = "a";
 
@@ -38,16 +43,17 @@
 		};
 	};
 
-	vreg_lt9611_vcc: regulator-lt9611-vcc {
+	vreg_disp_3p3: regulator-disp-3p3 {
 		compatible = "regulator-fixed";
-		regulator-name = "lt9611_vcc";
+		regulator-name = "vreg_disp_3p3";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		gpio = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		pinctrl-0 = <&lt9611_vcc_pin>;
+		pinctrl-0 = <&lcd_bias_en>;
 		pinctrl-names = "default";
 	};
+
 };
 
 &i2c2 {
@@ -58,7 +64,7 @@
 		reg = <0x41>;
 		interrupts-extended = <&tlmm 60 IRQ_TYPE_EDGE_FALLING>;
 		reset-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
-		vcc-supply = <&vreg_lt9611_vcc>;
+		vcc-supply = <&vreg_disp_3p3>;
 		vdd-supply = <&vreg_s4a>;
 
 		pinctrl-0 = <&lt9611_irq_pin &lt9611_rst_pin>;
@@ -87,19 +93,6 @@
 	};
 };
 
-&mdss {
-        status = "okay";
-};
-
-&mdss_dp0 {
-        status = "okay";
-};
-
-&mdss_dp0_out {
-        link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000>;
-        remote-endpoint = <&dp0_connector_in>;
-};
-
 &i2c5 {
 	status = "okay";
 
@@ -125,9 +118,25 @@
 	};
 };
 
-&mdss_dsi0 {
+&mdss {
 	status = "okay";
 };
+
+&mdss_dp0 {
+	status = "okay";
+};
+
+&mdss_dp0_out {
+	link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000>;
+	remote-endpoint = <&dp0_connector_in>;
+};
+
+&mdss_dsi0 {
+	vdda-supply = <&vreg_l5a>;
+
+	status = "okay";
+};
+
 
 &mdss_dsi0_out {
 	remote-endpoint = <&lt9611_a>;
@@ -135,6 +144,8 @@
 };
 
 &mdss_dsi0_phy {
+	vdds-supply = <&vreg_l11a>;
+
 	status = "okay";
 };
 
@@ -173,7 +184,7 @@
 		bias-disable;
 	};
 
-	lt9611_vcc_pin: lt9611-vcc-state {
+	lcd_bias_en: lcd-bias-en-state {
 		pins = "gpio3";
 		function = "gpio";
 		drive-strength = <8>;

--- a/drivers/regulator/rpi-panel-v2-regulator.c
+++ b/drivers/regulator/rpi-panel-v2-regulator.c
@@ -11,6 +11,7 @@
 #include <linux/module.h>
 #include <linux/pwm.h>
 #include <linux/regmap.h>
+#include <linux/regulator/consumer.h>
 
 /* I2C registers of the microcontroller. */
 #define REG_ID		0x01
@@ -66,9 +67,26 @@ static int rpi_panel_v2_i2c_probe(struct i2c_client *i2c)
 		.parent		= &i2c->dev,
 		.reg_set_base	= REG_POWERON,
 	};
+	struct regulator *vcc;
 	struct regmap *regmap;
 	struct pwm_chip *pc;
 	int ret;
+
+	vcc = devm_regulator_get_optional(&i2c->dev, "vcc");
+	if (IS_ERR(vcc)) {
+		ret = PTR_ERR(vcc);
+		if (ret == -EPROBE_DEFER)
+			return ret;
+		/* vcc-supply is optional, proceed without it */
+		vcc = NULL;
+	}
+
+	if (vcc) {
+		ret = regulator_enable(vcc);
+		if (ret)
+			return dev_err_probe(&i2c->dev, ret,
+					     "Failed to enable vcc supply\n");
+	}
 
 	pc = devm_pwmchip_alloc(&i2c->dev, 1, 0);
 	if (IS_ERR(pc))


### PR DESCRIPTION
Support Talos Lyra DSI panels.
 - Refactor base DT to make generic supplies
 - Add DLC DLC0697 panel
 - Add RPI 7inch 2 lane DSI panel