### PR TITLE
dt-bindings: interconnect: qcom-bwmon: add sa8797p compatibles

### DIFF
--- a/Documentation/devicetree/bindings/interconnect/qcom,msm8998-bwmon.yaml
+++ b/Documentation/devicetree/bindings/interconnect/qcom,msm8998-bwmon.yaml
@@ -34,6 +34,7 @@ properties:
               - qcom,qcs615-cpu-bwmon
               - qcom,qcs8300-cpu-bwmon
               - qcom,sa8775p-cpu-bwmon
+              - qcom,sa8797p-cpu-bwmon
               - qcom,sc7180-cpu-bwmon
               - qcom,sc7280-cpu-bwmon
               - qcom,sc8280xp-cpu-bwmon


### PR DESCRIPTION
Document the qcom,sa8797p-cpu-bwmon fallback compatibles used by the CPU bandwidth monitors on Nord Embedded.