### PR TITLE
FROMLIST: drm/panel-edp: Add support for BOE panel used in KD116N36-3…

### DIFF
--- a/drivers/gpu/drm/panel/panel-edp.c
+++ b/drivers/gpu/drm/panel/panel-edp.c
@@ -2020,6 +2020,7 @@ static const struct edp_panel_entry edp_panels[] = {
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0ae8, &delay_200_500_e50_p2e80, "NV140WUM-N41"),
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b09, &delay_200_500_e50_po2e200, "NV140FHM-NZ"),
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b1e, &delay_200_500_e80, "NE140QDM-N6A"),
+	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b21, &delay_200_500_e80, "QV116FHB-N81"),
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b34, &delay_200_500_e80_d50, "NV122WUM-N41"),
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b43, &delay_200_500_e200, "NV140FHM-T09"),
 	EDP_PANEL_ENTRY('B', 'O', 'E', 0x0b56, &delay_200_500_e80, "NT140FHM-N47"),


### PR DESCRIPTION
…0NB-A001

Add the BOE 0x0b21 panel entry used in the K&D Technology KD116N36-30NB-A001 eDP LCM, place the EDID here for subsequent reference. Timing values come from the KD116N36-30NB-A001 spec.

00 ff ff ff ff ff ff 00 09 e5 21 0b 00 00 00 00
01 1e 01 04 a5 1a 0e 78 0a 24 10 97 59 54 8e 27
1e 50 54 00 00 00 01 01 01 01 01 01 01 01 01 01
01 01 01 01 01 01 b2 39 80 d4 70 38 4b 40 30 20
36 00 04 8c 10 00 00 1a 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 1a 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fe
00 51 56 31 31 36 46 48 42 2d 4e 38 31 0a 00 b3


Link: https://lore.kernel.org/all/20260901-edp-id-boe-v1-1-f5e2c44255f7@oss.qualcomm.com
CRs-Fixed: 4562220