### PR TITLE
Enable audio support on talos-lyra-evk

### DIFF
--- a/Documentation/devicetree/bindings/pinctrl/qcom,qcs615-lpass-lpi-pinctrl.yaml
+++ b/Documentation/devicetree/bindings/pinctrl/qcom,qcs615-lpass-lpi-pinctrl.yaml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/pinctrl/qcom,qcs615-lpass-lpi-pinctrl.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Qualcomm QCS615 SoC LPASS LPI TLMM
+
+maintainers:
+  - Karthik S <karthik.s@oss.qualcomm.com>
+
+description:
+  Top Level Mode Multiplexer pin controller in the Low Power Audio SubSystem
+  (LPASS) Low Power Island (LPI) of Qualcomm QCS615 SoC.
+
+properties:
+  compatible:
+    const: qcom,qcs615-lpass-lpi-pinctrl
+
+  reg:
+    items:
+      - description: LPASS LPI TLMM Control and Status registers
+      - description: LPASS LPI MCC registers
+
+  clocks:
+    items:
+      - description: LPASS Core voting clock
+
+  clock-names:
+    items:
+      - const: core
+
+patternProperties:
+  "-state$":
+    oneOf:
+      - $ref: "#/$defs/qcom-qcs615-lpass-state"
+      - patternProperties:
+          "-pins$":
+            $ref: "#/$defs/qcom-qcs615-lpass-state"
+        additionalProperties: false
+
+$defs:
+  qcom-qcs615-lpass-state:
+    type: object
+    description:
+      Pinctrl node's client devices use subnodes for desired pin configuration.
+      Client device subnodes use below standard properties.
+    $ref: qcom,lpass-lpi-common.yaml#/$defs/qcom-tlmm-state
+    unevaluatedProperties: false
+
+    properties:
+      pins:
+        description:
+          List of gpio pins affected by the properties specified in this
+          subnode.
+        items:
+          pattern: "^gpio([0-9]|1[0-9]|2[0-9]|3[0-1])$"
+
+      function:
+        enum: [ dmic1_clk, dmic1_data, dmic2_clk, dmic2_data, gpio, i2s1_clk,
+                i2s1_data, i2s1_ws, spkr_i2s_mclk_a ]
+        description:
+          Specify the alternative function to be configured for the specified
+          pins.
+
+allOf:
+  - $ref: qcom,lpass-lpi-common.yaml#
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+
+unevaluatedProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/sound/qcom,q6afe.h>
+    lpi_tlmm: pinctrl@62b40000 {
+        compatible = "qcom,qcs615-lpass-lpi-pinctrl";
+        reg = <0x62b40000 0x20000>,
+              <0x62b00000 0x10000>;
+        clocks = <&q6afecc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+        clock-names = "core";
+        gpio-controller;
+        #gpio-cells = <2>;
+        gpio-ranges = <&lpi_tlmm 0 0 32>;
+
+        i2s1-active-state {
+            clk-pins {
+                pins = "gpio8";
+                function = "i2s1_clk";
+                drive-strength = <8>;
+                bias-disable;
+                output-high;
+            };
+
+            ws-pins {
+                pins = "gpio9";
+                function = "i2s1_ws";
+                drive-strength = <8>;
+                bias-disable;
+                output-high;
+            };
+
+            data-pins {
+                pins = "gpio10", "gpio11";
+                function = "i2s1_data";
+                drive-strength = <8>;
+                bias-disable;
+            };
+        };
+    };

--- a/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
+++ b/Documentation/devicetree/bindings/sound/qcom,sm8250.yaml
@@ -53,6 +53,7 @@ properties:
           - qcom,sdm845-sndcard
           - qcom,sm8250-sndcard
           - qcom,sm8450-sndcard
+          - qcom,talos-lyra-sndcard
           - qcom,x1e80100-sndcard
 
   audio-routing:

--- a/drivers/pinctrl/qcom/Kconfig
+++ b/drivers/pinctrl/qcom/Kconfig
@@ -62,6 +62,16 @@ config PINCTRL_LPASS_LPI
 	  Qualcomm Technologies Inc LPASS (Low Power Audio SubSystem) LPI
 	  (Low Power Island) found on the Qualcomm Technologies Inc SoCs.
 
+config PINCTRL_QCS615_LPASS_LPI
+       tristate "Qualcomm Technologies Inc QCS615 LPASS LPI pin controller driver"
+       depends on ARM64 || COMPILE_TEST
+       depends on PINCTRL_LPASS_LPI
+       help
+         This is the pinctrl, pinmux, pinconf and gpiolib driver for the
+         Qualcomm Technologies Inc LPASS (Low Power Audio SubSystem) LPI
+         (Low Power Island) found on the Qualcomm Technologies Inc QCS615
+         platform.
+
 config PINCTRL_MILOS_LPASS_LPI
 	tristate "Qualcomm Milos LPASS LPI pin controller driver"
 	depends on ARM64 || COMPILE_TEST

--- a/drivers/pinctrl/qcom/Makefile
+++ b/drivers/pinctrl/qcom/Makefile
@@ -33,6 +33,7 @@ obj-$(CONFIG_PINCTRL_MSM8998)   += pinctrl-msm8998.o
 obj-$(CONFIG_PINCTRL_QCM2290)	+= pinctrl-qcm2290.o
 obj-$(CONFIG_PINCTRL_QCS404)	+= pinctrl-qcs404.o
 obj-$(CONFIG_PINCTRL_QCS615)    += pinctrl-qcs615.o
+obj-$(CONFIG_PINCTRL_QCS615_LPASS_LPI) += pinctrl-qcs615-lpass-lpi.o
 obj-$(CONFIG_PINCTRL_QCS8300)	+= pinctrl-qcs8300.o
 obj-$(CONFIG_PINCTRL_QDF2XXX)	+= pinctrl-qdf2xxx.o
 obj-$(CONFIG_PINCTRL_MDM9607)	+= pinctrl-mdm9607.o

--- a/drivers/pinctrl/qcom/pinctrl-qcs615-lpass-lpi.c
+++ b/drivers/pinctrl/qcom/pinctrl-qcs615-lpass-lpi.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * ALSA SoC platform-machine driver for QTi LPASS
+ */
+
+#include <linux/gpio/driver.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/pm_clock.h>
+#include <linux/pm_runtime.h>
+
+#include "pinctrl-lpass-lpi.h"
+
+enum lpass_lpi_functions {
+	LPI_MUX_i2s1_clk,
+	LPI_MUX_i2s1_ws,
+	LPI_MUX_i2s1_data,
+	LPI_MUX_spkr_i2s_mclk_a,
+	LPI_MUX_dmic1_clk,
+	LPI_MUX_dmic1_data,
+	LPI_MUX_dmic2_clk,
+	LPI_MUX_dmic2_data,
+	LPI_MUX_gpio,
+	LPI_MUX__,
+};
+
+static int gpio8_pins[] = { 8 };
+static int gpio9_pins[] = { 9 };
+static int gpio10_pins[] = { 10 };
+static int gpio11_pins[] = { 11 };
+static int gpio19_pins[] = { 19 };
+static int gpio26_pins[] = { 26 };
+static int gpio27_pins[] = { 27 };
+static int gpio28_pins[] = { 28 };
+static int gpio29_pins[] = { 29 };
+static int gpio0_pins[] = { 0 };
+static int gpio1_pins[] = { 1 };
+static int gpio2_pins[] = { 2 };
+static int gpio3_pins[] = { 3 };
+static int gpio4_pins[] = { 4 };
+static int gpio5_pins[] = { 5 };
+static int gpio6_pins[] = { 6 };
+static int gpio7_pins[] = { 7 };
+static int gpio12_pins[] = { 12 };
+static int gpio13_pins[] = { 13 };
+static int gpio14_pins[] = { 14 };
+static int gpio15_pins[] = { 15 };
+static int gpio16_pins[] = { 16 };
+static int gpio17_pins[] = { 17 };
+static int gpio18_pins[] = { 18 };
+static int gpio20_pins[] = { 20 };
+static int gpio21_pins[] = { 21 };
+static int gpio22_pins[] = { 22 };
+static int gpio23_pins[] = { 23 };
+static int gpio24_pins[] = { 24 };
+static int gpio25_pins[] = { 25 };
+static int gpio30_pins[] = { 30 };
+static int gpio31_pins[] = { 31 };
+
+static const struct pinctrl_pin_desc qcs615_lpi_pins[] = {
+	PINCTRL_PIN(0,  "gpio0"),
+	PINCTRL_PIN(1,  "gpio1"),
+	PINCTRL_PIN(2,  "gpio2"),
+	PINCTRL_PIN(3,  "gpio3"),
+	PINCTRL_PIN(4,  "gpio4"),
+	PINCTRL_PIN(5,  "gpio5"),
+	PINCTRL_PIN(6,  "gpio6"),
+	PINCTRL_PIN(7,  "gpio7"),
+	PINCTRL_PIN(8,  "gpio8"),
+	PINCTRL_PIN(9,  "gpio9"),
+	PINCTRL_PIN(10, "gpio10"),
+	PINCTRL_PIN(11, "gpio11"),
+	PINCTRL_PIN(12, "gpio12"),
+	PINCTRL_PIN(13, "gpio13"),
+	PINCTRL_PIN(14, "gpio14"),
+	PINCTRL_PIN(15, "gpio15"),
+	PINCTRL_PIN(16, "gpio16"),
+	PINCTRL_PIN(17, "gpio17"),
+	PINCTRL_PIN(18, "gpio18"),
+	PINCTRL_PIN(19, "gpio19"),
+	PINCTRL_PIN(20, "gpio20"),
+	PINCTRL_PIN(21, "gpio21"),
+	PINCTRL_PIN(22, "gpio22"),
+	PINCTRL_PIN(23, "gpio23"),
+	PINCTRL_PIN(24, "gpio24"),
+	PINCTRL_PIN(25, "gpio25"),
+	PINCTRL_PIN(26, "gpio26"),
+	PINCTRL_PIN(27, "gpio27"),
+	PINCTRL_PIN(28, "gpio28"),
+	PINCTRL_PIN(29, "gpio29"),
+	PINCTRL_PIN(30, "gpio30"),
+	PINCTRL_PIN(31, "gpio31"),
+};
+
+static const char * const i2s1_clk_groups[] = { "gpio8" };
+static const char * const i2s1_ws_groups[] = { "gpio9" };
+static const char * const i2s1_data_groups[] = { "gpio10", "gpio11" };
+static const char * const spkr_i2s_mclk_a_groups[] = { "gpio19" };
+static const char * const dmic1_clk_groups[] = { "gpio26" };
+static const char * const dmic1_data_groups[] = { "gpio27" };
+static const char * const dmic2_clk_groups[] = { "gpio28" };
+static const char * const dmic2_data_groups[] = { "gpio29" };
+
+static const struct lpi_pingroup qcs615_groups[] = {
+	LPI_PINGROUP(0,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(1,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(2,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(3,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(4,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(5,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(6,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(7,  LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(8,  LPI_NO_SLEW, _, _, i2s1_clk, _),
+	LPI_PINGROUP(9,  LPI_NO_SLEW, _, _, i2s1_ws, _),
+	LPI_PINGROUP(10, LPI_NO_SLEW, _, _, _, i2s1_data),
+	LPI_PINGROUP(11, LPI_NO_SLEW, _, i2s1_data, _, _),
+	LPI_PINGROUP(12, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(13, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(14, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(15, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(16, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(17, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(18, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(19, LPI_NO_SLEW, spkr_i2s_mclk_a, _, _, _),
+	LPI_PINGROUP(20, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(21, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(22, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(23, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(24, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(25, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(26, LPI_NO_SLEW, dmic1_clk, _, _, _),
+	LPI_PINGROUP(27, LPI_NO_SLEW, dmic1_data, _, _, _),
+	LPI_PINGROUP(28, LPI_NO_SLEW, dmic2_clk, _, _, _),
+	LPI_PINGROUP(29, LPI_NO_SLEW, dmic2_data, _, _, _),
+	LPI_PINGROUP(30, LPI_NO_SLEW, _, _, _, _),
+	LPI_PINGROUP(31, LPI_NO_SLEW, _, _, _, _),
+};
+
+static const struct lpi_function qcs615_functions[] = {
+	LPI_FUNCTION(i2s1_clk),
+	LPI_FUNCTION(i2s1_ws),
+	LPI_FUNCTION(i2s1_data),
+	LPI_FUNCTION(spkr_i2s_mclk_a),
+	LPI_FUNCTION(dmic1_clk),
+	LPI_FUNCTION(dmic1_data),
+	LPI_FUNCTION(dmic2_clk),
+	LPI_FUNCTION(dmic2_data),
+};
+
+static const struct lpi_pinctrl_variant_data qcs615_lpi_data = {
+	.pins = qcs615_lpi_pins,
+	.npins = ARRAY_SIZE(qcs615_lpi_pins),
+	.groups = qcs615_groups,
+	.ngroups = ARRAY_SIZE(qcs615_groups),
+	.functions = qcs615_functions,
+	.nfunctions = ARRAY_SIZE(qcs615_functions),
+};
+
+static const struct of_device_id lpi_pinctrl_of_match[] = {
+	{
+	       .compatible = "qcom,qcs615-lpass-lpi-pinctrl",
+	       .data = &qcs615_lpi_data,
+	},
+	{ }
+};
+MODULE_DEVICE_TABLE(of, lpi_pinctrl_of_match);
+
+static const struct dev_pm_ops lpi_pinctrl_pm_ops = {
+        RUNTIME_PM_OPS(pm_clk_suspend, pm_clk_resume, NULL)
+};
+
+static struct platform_driver lpi_pinctrl_driver = {
+	.driver = {
+		   .name = "qcom-qcs615-lpass-lpi-pinctrl",
+		   .of_match_table = lpi_pinctrl_of_match,
+		   .pm = pm_ptr(&lpi_pinctrl_pm_ops),
+	},
+	.probe = lpi_pinctrl_probe,
+	.remove = lpi_pinctrl_remove,
+};
+
+module_platform_driver(lpi_pinctrl_driver);
+MODULE_DESCRIPTION("QTI QCS615 LPI GPIO pin control driver");
+MODULE_LICENSE("GPL");

--- a/sound/soc/qcom/sc8280xp.c
+++ b/sound/soc/qcom/sc8280xp.c
@@ -40,8 +40,9 @@ static struct snd_soc_dapm_widget sc8280xp_dapm_widgets[] = {
 
 static const struct snd_kcontrol_new max98090_controls[] = {
 	SOC_DAPM_PIN_SWITCH("Headset Mic12"),
-	SOC_DAPM_PIN_SWITCH("Headphone"),
+	SOC_DAPM_PIN_SWITCH("Headset Mic34"),
 	SOC_DAPM_PIN_SWITCH("Headset Mic56"),
+	SOC_DAPM_PIN_SWITCH("Headphone"),
 	SOC_DAPM_PIN_SWITCH("Speaker"),
 	SOC_DAPM_PIN_SWITCH("Receiver"),
 	SOC_DAPM_PIN_SWITCH("Int Mic"),
@@ -52,10 +53,26 @@ static const struct snd_soc_dapm_widget max98090_dapm_widgets[] = {
 	SND_SOC_DAPM_MIC("Mic Jack", NULL),
 	SND_SOC_DAPM_HP("Headphone", NULL),
 	SND_SOC_DAPM_MIC("Headset Mic12", NULL),
+	SND_SOC_DAPM_MIC("Headset Mic34", NULL),
 	SND_SOC_DAPM_MIC("Headset Mic56", NULL),
 	SND_SOC_DAPM_MIC("Int Mic", NULL),
 	SND_SOC_DAPM_SPK("Receiver", NULL),
 	SND_SOC_DAPM_SPK("Speaker", NULL),
+};
+
+static const struct snd_soc_dapm_route talos_lyra_dapm_routes[] = {
+        {"IN12", NULL, "Headset Mic12"},
+        {"Headset Mic12", NULL, "MICBIAS"},
+        {"IN34", NULL, "Headset Mic34"},
+        {"Headset Mic34", NULL, "MICBIAS"},
+        {"IN56", NULL, "Headset Mic56"},
+        {"Headset Mic56", NULL, "MICBIAS"},
+        {"Headphone", NULL, "HPL"},
+        {"Headphone", NULL, "HPR"},
+        {"Receiver", NULL, "RCVL"},
+        {"Receiver", NULL, "RCVR"},
+        {"Speaker", NULL, "SPKL"},
+        {"Speaker", NULL, "SPKR"},
 };
 
 struct qcom_snd_soc_common {
@@ -474,6 +491,18 @@ static const struct qcom_snd_soc_common qcs615_priv_data = {
 	.codec_sysclk_set = true,
 };
 
+static const struct qcom_snd_soc_common talos_lyra_priv_data = {
+        .driver_name = "qcs615",
+        .dapm_widgets = max98090_dapm_widgets,
+        .num_dapm_widgets = ARRAY_SIZE(max98090_dapm_widgets),
+        .dapm_routes = talos_lyra_dapm_routes,
+        .num_dapm_routes = ARRAY_SIZE(talos_lyra_dapm_routes),
+        .controls = max98090_controls,
+        .num_controls = ARRAY_SIZE(max98090_controls),
+        .codec_dai_fmt = SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_BC_FC,
+        .codec_sysclk_set = true,
+};
+
 static const struct qcom_snd_soc_common qcm6490_priv_data = {
 	.driver_name = "qcm6490",
 	.dapm_widgets = sc8280xp_dapm_widgets,
@@ -576,6 +605,7 @@ static const struct of_device_id snd_sc8280xp_dt_match[] = {
 	{ .compatible = "qcom,sm8550-sndcard", .data = &sm8550_priv_data },
 	{ .compatible = "qcom,sm8650-sndcard", .data = &sm8650_priv_data },
 	{ .compatible = "qcom,sm8750-sndcard", .data = &sm8750_priv_data },
+	{ .compatible = "qcom,talos-lyra-sndcard", .data = &talos_lyra_priv_data },
 	{}
 };
 


### PR DESCRIPTION
This series includes:
pinctrl: qcom: add QCS615 LPASS LPI pinctrl driver
Add the LPASS LPI pinctrl driver for the QCS615 SoC. The driver
supports 32 GPIOs in the range 0-31 and provides pin control
functionality for the LPASS LPI block.

ASoC: qcom: sc8280xp: enable support for talos-lyra
Add the necessary board widgets, kcontrols and DAPM routes
for max98091 codec support. Enable required DAI format, sysclk
and other required configs.

Link: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-172
CRs-Fixed: 4670734