### PR TITLE
FROMLIST: net: stmmac: qcom-ethqos: set initial RGMII link clock to lowest speed

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
@@ -759,7 +759,7 @@ static int qcom_ethqos_probe(struct platform_device *pdev)
 				     "Failed to get serdes phy\n");
 
 	ethqos_set_clk_tx_rate(ethqos, NULL, plat_dat->phy_interface,
-			       SPEED_1000);
+			       SPEED_10);
 
 	qcom_ethqos_set_sgmii_loopback(ethqos, true);
 	ethqos_set_func_clk_en(ethqos);


### PR DESCRIPTION
On probe the RGMII link clock is initialised at SPEED_1000, which translates to a 250 MHz source clock even when no PHY link is present, drawing unnecessary power.

Initialise at SPEED_10 instead; fix_mac_speed updates the rate once a link is established.

Link: https://lore.kernel.org/netdev/20260908-shikra_ethernet-v2-7-bbe3389d0652@oss.qualcomm.com
Reviewed-by: Maxime Chevallier <maxime.chevallier@bootlin.com>

CRs-Fixed: 4601298