### PR TITLE
FROMLIST: clk: qcom: smd-rpm: Skip proxy votes on clocks for QCM2290

### DIFF
--- a/drivers/clk/qcom/clk-smd-rpm.c
+++ b/drivers/clk/qcom/clk-smd-rpm.c
@@ -183,6 +183,7 @@ struct rpm_smd_clk_desc {
 	const struct clk_smd_rpm ** const icc_clks;
 	size_t num_icc_clks;
 	bool scaling_before_handover;
+	bool skip_clks_handoff;
 };
 
 static DEFINE_MUTEX(rpm_smd_clk_lock);
@@ -1280,7 +1281,8 @@ static const struct rpm_smd_clk_desc rpm_clk_qcm2290 = {
 	.clks = qcm2290_clks,
 	.num_clks = ARRAY_SIZE(qcm2290_clks),
 	.icc_clks = qcm2290_icc_clks,
-	.num_icc_clks = ARRAY_SIZE(qcm2290_icc_clks)
+	.num_icc_clks = ARRAY_SIZE(qcm2290_icc_clks),
+	.skip_clks_handoff = true,
 };
 
 static const struct of_device_id rpm_smd_clk_match_table[] = {
@@ -1358,13 +1360,15 @@ static int rpm_smd_clk_probe(struct platform_device *pdev)
 			goto err;
 	}
 
-	for (i = 0; i < num_clks; i++) {
-		if (!rpm_smd_clks[i])
-			continue;
+	if (!desc->skip_clks_handoff) {
+		for (i = 0; i < num_clks; i++) {
+			if (!rpm_smd_clks[i])
+				continue;
 
-		ret = clk_smd_rpm_handoff(rpm_smd_clks[i]);
-		if (ret)
-			goto err;
+			ret = clk_smd_rpm_handoff(rpm_smd_clks[i]);
+			if (ret)
+				goto err;
+		}
 	}
 
 	for (i = 0; i < desc->num_icc_clks; i++) {


### PR DESCRIPTION
clk_smd_rpm_handoff() votes both active and sleep RPM resource states for every clock, keeping them non-zero until a consumer takes over. If there is no consumer, those clocks will remain active in the idle scenario as well, and the sleep vote is never cleared, blocking XO shutdown.

Introduce the skip_clks_handoff flag to handle this on QCM2290 clocks, keeping other targets unaffected.

Link: https://lore.kernel.org/r/20260910-clk-smd-rpm-skip-proxy-v1-1-1cb5694a99d9@oss.qualcomm.com
Fixes: 00f64b58874e ("clk: qcom: Add support for SMD-RPM Clocks")

CRs-Fixed: 4635293