### PR TITLE
QCLINUX : arm64: dts: qcom: Remove sa8775p-ride composite DTB rules

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -600,14 +600,7 @@ qcs9100-ride-r3-camx-dtbs:= qcs9100-ride-r3.dtb sa8775p-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride-r3-camx.dtb
 
-sa8775p-ride-camx-dtbs:= sa8775p-ride.dtb sa8775p-ride-camx.dtbo
-
-dtb-$(CONFIG_ARCH_QCOM)	+= sa8775p-ride-camx.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sa8775p-ride-camx.dtbo
-
-sa8775p-ride-r3-camx-dtbs:= sa8775p-ride-r3.dtb sa8775p-ride-camx.dtbo
-
-dtb-$(CONFIG_ARCH_QCOM)	+= sa8775p-ride-r3-camx.dtb
 
 talos-evk-camx-dtbs	:= talos-evk.dtb talos-evk-camx.dtbo
 


### PR DESCRIPTION
sa8775p-ride.dts and sa8775p-ride-r3.dts do not exist in the tree, removed as part of https://github.com/qualcomm-linux/kernel/commit/921f145639e4

Remove the composite-DTB rules and their dtb-y install entries.